### PR TITLE
fix typo in manual

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -3072,7 +3072,7 @@ For equations the following might work:
   Therefore it is not clear in general which \verb|\footnotemark| references
   which \verb|\footnotetext|. But that is necessary to implement hyperlinking.
   Thus the implementation of hyperref does not support the optional
-  argument of \verb|\footnotemark\verb| and \verb|\footnotetext|.
+  argument of \verb|\footnotemark| and \verb|\footnotetext|.
 
 
 \section[Hints]{Hints%


### PR DESCRIPTION
Delete redundant `\verb` in
```tex
Thus the implementation of hyperref does not support the optional
argument of \verb|\footnotemark\verb| and \verb|\footnotetext|.
```