### PR TITLE
remove the `HyPsd@XeTeXBigChar` code

### DIFF
--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -2979,50 +2979,20 @@ For equations the following might work:
 \subsubsection{XeTeX}
 
  Default for the encoding of bookmarks is `pdfencoding=auto'.
-  That means the strings are always treated as unicode strings.
-  Only if the string restricts to the printable ASCII set,
+ That means the strings are always treated as unicode strings.
+ Only if the string restricts to the printable ASCII set,
   it is written as ASCII string. The reason is that the
   \verb|\special| does not support PDFDocEncoding.
 
-
-
- XeTeX uses the program xdvipdfmx for PDF output generation.
-  This program behaves a little different from dvipdfm, because
-  of the supported Unicode characters. Strings for bookmarks
-  or information entries can be output directly. The
-  big chars (char code > 255) are written in UTF-8 and
-  xdvipdfmx tries to convert them to UTF-16BE. However
-  hyperref already provides PDF strings encoded in UTF-16BE,
-  thus the result is a warning
-
-    \verb"Failed to convert input string to UTF16..."
-
-  The best way would be, if xdvipdfm could detect the
-  byte order marker (\verb|\376\377|) and skips the conversion
-  if that marker is present.
-
-    For the time being I added the following to hyperref,
-  when option `pdfencoding=auto' is set (default for XeTeX):
-  The string is converted back to big characters thus that the
-  string is written as UTF-8. But I am very unhappy with this
-  solution. Main disadvantage:
-  Two versions of \verb|\pdfstringdef| are needed:
-
-  a) The string is converted back to big characters for
-     the ``tainted key'' of xdvipdfmx (\verb|spc_pdfm.c: default_taintkeys|).
-     The subset hyperref uses is /Title, /Author, /Subject,
-     /Keywords, /Creator, /Producer, /T. Any changes of this
-     set in xdvipdfmx cannot be detected by hyperref.
-
-  b) Without conversion for the other strings , providing UTF16be
-     directly. Examples: Prefix of page labels, some elements
-     of formulars.
-
-  Thus \textbf{each} application that uses \verb|\pdfstringdef| now must
-  check, if it defines a string for some of the tained keys.
-  If yes, then the call of \verb|\pdfstringdef| should be preceded
-  by \verb|\csname HyPsd@XeTeXBigCharstrue\endcsname|.
-  Example: package bookmark.
+ In older versions hyperref contained special conversion code from
+ UTF-16BE back to UTF-8 in a number of places for
+ xetex to avoid the xdvipdfmx warning 
+ 
+   \verb"Failed to convert input string to UTF16..."
+   
+ This is no longer needed with a current xdvipdfmx, so this code has
+ been removed. \verb|\csname HyPsd@XeTeXBigCharstrue\endcsname| should no
+ longer be used.    
 
 
 \section[Limitations]{Limitations%

--- a/hluatex.dtx
+++ b/hluatex.dtx
@@ -1365,7 +1365,6 @@
         \Hy@unicodefalse
       \fi
     \fi
-    \HyPsd@XeTeXBigCharstrue
     \pdfstringdef\Hy@gtemp#1%
   \endgroup
   \let#1\Hy@gtemp
@@ -1721,7 +1720,6 @@
         \let\partnumberline\@gobble
         \let\chapternumberline\@gobble
       \fi
-      \HyPsd@XeTeXBigCharstrue
       \pdfstringdef\Hy@tempa{#2}%
       \HyPsd@SanitizeForOutFile\Hy@tempa
       \if@filesw

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -1911,7 +1911,6 @@
               \HyPsd@EscapeTeX#1%
               \Hy@unicodefalse
             }{%
-              \HyPsd@ToBigChars#1%
               \HyPsd@EscapeTeX#1%
             }%
           \else
@@ -1926,7 +1925,6 @@
         }%
       \fi
     \fi
-    \HyPsd@XeTeXBigCharsfalse
 %    \end{macrocode}
 %
 % \paragraph{User hook.}
@@ -1951,82 +1949,8 @@
 % \subsection{Encodings}
 %
 % \subsubsection{Xe\TeX}
-%
-%    \begin{macrocode}
-\edef\Hy@temp{\catcode0=\the\catcode0\relax}
-\catcode\z@=12 %
-\ifxetex
-  \expandafter\@firstofone
-\else
-  \let\HyPsd@XeTeXBigCharstrue\@empty
-  \let\HyPsd@XeTeXBigCharsfalse\@empty
-  \expandafter\@gobble
-\fi
-{%
-  \newif\ifHyPsd@XeTeXBigChars
-  \def\HyPsd@XeTeXBigCharsfalse{%
-    \global\let\ifHyPsd@XeTeXBigChars\iffalse
-  }%
-  \def\HyPsd@XeTeXBigCharstrue{%
-    \global\let\ifHyPsd@XeTeXBigChars\iftrue
-  }%
-  \def\HyPsd@ToBigChars#1{%
-    \ifHyPsd@XeTeXBigChars
-      \EdefEscapeHex\HyPsd@UnescapedString{%
-        \expandafter\@gobbletwo\HyPsd@UnescapedString
-      }%
-      \begingroup
-        \toks@{}%
-        \escapechar=92\relax
-        \let\x\HyPsd@ToBigChar
-        \expandafter\HyPsd@ToBigChar\HyPsd@UnescapedString
-        \relax\relax\relax\relax\relax\relax\relax
-      \edef\x{%
-        \endgroup
-        \gdef\noexpand#1{\the\toks@}%
-      }%
-      \x
-    \fi
-  }%
-  \def\HyPsd@ToBigChar#1#2#3#4{%
-    \ifx\relax#1\relax
-      \let\x\relax
-    \else
-      \count@="#1#2#3#4\relax
-      \let\y\@empty
-      \lccode\z@=\count@
-      \ifnum\count@=40 % (
-        \let\y\@backslashchar
-      \else
-        \ifnum\count@=41 % )
-          \let\y\@backslashchar
-        \else
-          \ifnum\count@=92 % backslash
-            \let\y\@backslashchar
-          \else
-            \ifnum\count@=10 % newline
-              \edef\y##1{\string\n}%
-            \else
-              \ifnum\count@=13 % carriage return
-                \edef\y##1{\string\r}%
-              \fi
-            \fi
-          \fi
-        \fi
-      \fi
-      \lowercase{%
-        \toks@\expandafter{%
-          \the\expandafter\toks@
-          \y
-          ^^@%
-        }%
-      }%
-    \fi
-    \x
-  }%
-}
-\Hy@temp
-%    \end{macrocode}
+% change 2020-05-13: the special code for XeTeX big chars has been removed as no
+% longer needed.
 %
 % \subsubsection{Workaround for package linguex}
 %
@@ -5289,7 +5213,7 @@
   }%
 }
 %    \end{macrocode}
-% \verb|\Hy@pdfminorversion| already used elsewhere to denote \verb|\pdfminorversion| 
+% \verb|\Hy@pdfminorversion| already used elsewhere to denote \verb|\pdfminorversion|
 % or \verb|\pdfvariable majorversion}| so introduce new names here.
 %    \begin{macrocode}
 \@namedef{Hy@pdfversion@1.2}{\def\Hy@pdf@majorversion{1}\def\Hy@pdf@minorversion{2}}%
@@ -5312,7 +5236,7 @@
 \@ifundefined{pdfminorversion}{}{%
 \@ifundefined{pdfmajorversion}{%
 \newcount\pdfmajorversion
-\pdfmajorversion=1 
+\pdfmajorversion=1
 }{}%
 }
 \ifx\pdfmajorversion\@undefined\else
@@ -6598,31 +6522,26 @@
 }
 \define@key{Hyp}{pdftitle}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdftitle{#1}%
 }
 \define@key{Hyp}{pdfauthor}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdfauthor{#1}%
 }
 \define@key{Hyp}{pdfproducer}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdfproducer{#1}%
 }
 \define@key{Hyp}{pdfcreator}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdfcreator{#1}%
 }
 \define@key{Hyp}{addtopdfcreator}{%
  \HyXeTeX@CheckUnicode
- \HyPsd@XeTeXBigCharstrue
  \HyPsd@PrerenderUnicode{#1}%
  \pdfstringdef\@pdfcreator{\@pdfcreator, #1}%
 }
@@ -6640,13 +6559,11 @@
 }
 \define@key{Hyp}{pdfsubject}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdfsubject{#1}%
 }
 \define@key{Hyp}{pdfkeywords}{%
   \HyXeTeX@CheckUnicode
-  \HyPsd@XeTeXBigCharstrue
   \HyPsd@PrerenderUnicode{#1}%
   \pdfstringdef\@pdfkeywords{#1}%
 }
@@ -6727,7 +6644,6 @@
         \def\HyInfo@tmp##1{%
           \kv@define@key{pdfinfo}{##1}{%
             \HyXeTeX@CheckUnicode
-            \HyPsd@XeTeXBigCharstrue
             \HyPsd@PrerenderUnicode{####1}%
             \pdfstringdef\HyInfo@Value{####1}%
             \global\expandafter
@@ -19832,7 +19748,6 @@
         \Hy@unicodefalse
       \fi
     \fi
-    \HyPsd@XeTeXBigCharstrue
     \pdfstringdef\Hy@gtemp#1%
   \endgroup
   \let#1\Hy@gtemp
@@ -20324,7 +20239,6 @@
         \let\partnumberline\@gobble
         \let\chapternumberline\@gobble
       \fi
-      \HyPsd@XeTeXBigCharstrue
       \pdfstringdef\Hy@tempa{#2}%
       \HyPsd@SanitizeForOutFile\Hy@tempa
       \if@filesw

--- a/testfiles-pvt/unicode-test.luatex.tpf
+++ b/testfiles-pvt/unicode-test.luatex.tpf
@@ -1,0 +1,401 @@
+%PDF-1.5
+%Ã’¡‘≈ÿ–ƒ∆
+1 0 obj
+<< /S /GoTo /D (section.1) >>
+endobj
+4 0 obj
+(\376\377\000G\000r\000\374\000\337\000e\145\351\231\020\330\076\335\206)
+endobj
+5 0 obj
+<< /S /GoTo /D [ 6 0 R /Fit ] >>
+endobj
+10 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [ 0 0 3.905 7.054 ] /Matrix [ 1 0 0 1 0 0 ] /Resources 11 0 R /Length 45 >>         
+stream
+BT
+/F28 9.96264 Tf
+1 0 0 1 0 0 Tm [({)]TJ
+ET
+endstream
+endobj
+11 0 obj
+<< /Font << /F28 12 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+13 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [ 0 0 36.503 14.127 ] /Matrix [ 1 0 0 1 0 0 ] /Resources 14 0 R /Length 328 >>        
+stream
+q
+1 0 0 1 0 13.928 cm
+[] 0 d 0 J 0.398 w 0 0 m 36.503 0 l S
+Q
+q
+1 0 0 1 0.199 0.398 cm
+[] 0 d 0 J 0.398 w 0 0 m 0 13.33 l S
+Q
+BT
+/F29 9.96264 Tf
+1 0 0 1 3.387 3.606 Tm [<0061006D0023004B00420069>]TJ
+ET
+q
+1 0 0 1 36.304 0.398 cm
+[] 0 d 0 J 0.398 w 0 0 m 0 13.33 l S
+Q
+q
+1 0 0 1 0 0.199 cm
+[] 0 d 0 J 0.398 w 0 0 m 36.503 0 l S
+Q
+endstream
+endobj
+14 0 obj
+<< /Font << /F29 15 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+16 0 obj
+<< /Type /XObject /Subtype /Form /FormType 1 /BBox [ 0 0 42.869 14.127 ] /Matrix [ 1 0 0 1 0 0 ] /Resources 17 0 R /Length 331 >>        
+stream
+q
+1 0 0 1 0 13.928 cm
+[] 0 d 0 J 0.398 w 0 0 m 42.869 0 l S
+Q
+q
+1 0 0 1 0.199 0.398 cm
+[] 0 d 0 J 0.398 w 0 0 m 0 13.33 l S
+Q
+BT
+/F29 9.96264 Tf
+1 0 0 1 3.387 3.606 Tm [<0061006D0023004B004200690053>]TJ
+ET
+q
+1 0 0 1 42.67 0.398 cm
+[] 0 d 0 J 0.398 w 0 0 m 0 13.33 l S
+Q
+q
+1 0 0 1 0 0.199 cm
+[] 0 d 0 J 0.398 w 0 0 m 42.869 0 l S
+Q
+endstream
+endobj
+17 0 obj
+<< /Font << /F29 15 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+20 0 obj
+<< /Length 188 >>        
+stream
+BT
+/F27 14.3462 Tf
+1 0 0 1 133.768 657.235 Tm [<0052>-1000<001C0023>-31<002B>]TJ
+/F25 9.96264 Tf
+1 0 0 1 133.768 635.404 Tm [<001C0023>-28<002B>]TJ
+1 0 0 1 303.133 89.365 Tm [<0052>]TJ
+ET
+endstream
+endobj
+6 0 obj
+<< /Type /Page /Contents 20 0 R /Resources 19 0 R /MediaBox [ 0 0 612 792 ] /Parent 25 0 R /Annots 26 0 R >>
+endobj
+26 0 obj
+[ 18 0 R ]
+endobj
+7 0 obj
+<</Type/Encoding/Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]>>
+endobj
+8 0 obj
+<</Type/Font/Subtype/Type1/Name/ZaDb/BaseFont/ZapfDingbats>>
+endobj
+9 0 obj
+<</Type/Font/Subtype/Type1/Name/Helv/BaseFont/Helvetica/Encoding 7 0 R>>
+endobj
+18 0 obj
+<< /Type /Annot /Rect [ 147.716 621.347 234.748 635.295 ]
+ /Subtype/Widget/F 4/T(\376\377\000g\000r\000\374\000\337\000e\145\351\231\020\330\076\335\206)/FT/Tx/Q 0/BS<</W 1 /S /S>>/MK<</BC[1 0 0]/BG[1 1 1]>>/DA(/Helv 10 Tf 0 0 0 rg)/DV()/V()
+ >>
+endobj
+21 0 obj
+<< /D [ 6 0 R /XYZ 132.768 705.06 null ] >>
+endobj
+22 0 obj
+<< /D [ 6 0 R /XYZ 133.768 667.198 null ] >>
+endobj
+2 0 obj
+<< /D [ 6 0 R /XYZ 133.768 667.198 null ] >>
+endobj
+19 0 obj
+<< /Font << /F27 23 0 R /F25 24 0 R >> /ProcSet [ /PDF /Text ] >>
+endobj
+27 0 obj
+<</Fields[18 0 R]/DR<</Font<</ZaDb 8 0 R/Helv 9 0 R>>>>/DA(/Helv 10 Tf 0 g)/NeedAppearances true>>
+endobj
+28 0 obj
+[ 28 [ 500 ] 35 [ 556 ] 43 [ 444 ] 82 [ 500 ] ]
+endobj
+30 0 obj
+<< /Length 11 >>         
+[BINARY STREAM]
+endobj
+31 0 obj
+<< /Subtype /CIDFontType0C /Length 955 >>        
+[BINARY STREAM]
+endobj
+29 0 obj
+<< /Type /FontDescriptor /FontName /NSMWQI+LMRoman10-Regular /Flags 4 /FontBBox [ -430 -290 1417 1127 ] /Ascent 1127 /CapHeight 683 /Descent -290 /ItalicAngle 0 /StemV 93 /XHeight 431 /FontFile3 31 0 R /CIDSet 30 0 R >>
+endobj
+32 0 obj
+<< /Length 734 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-NSMWQI-LMRoman10-Regular-0)
+%%Title: (TeX-NSMWQI-LMRoman10-Regular-0 TeX NSMWQI-LMRoman10-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (NSMWQI-LMRoman10-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-NSMWQI-LMRoman10-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+4 beginbfchar
+<001C> <0061>
+<0023> <0062>
+<002B> <0063>
+<0052> <0031>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+24 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /NSMWQI+LMRoman10-Regular /DescendantFonts [ 33 0 R ] /ToUnicode 32 0 R >>
+endobj
+33 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /NSMWQI+LMRoman10-Regular /FontDescriptor 29 0 R /W 28 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+34 0 obj
+[ 28 [ 547 ] 35 [ 625 ] 43 [ 500 ] 82 [ 563 ] ]
+endobj
+36 0 obj
+<< /Length 11 >>         
+[BINARY STREAM]
+endobj
+37 0 obj
+<< /Subtype /CIDFontType0C /Length 910 >>        
+[BINARY STREAM]
+endobj
+35 0 obj
+<< /Type /FontDescriptor /FontName /RJDCDH+LMRoman12-Bold /Flags 4 /FontBBox [ -476 -289 1577 1137 ] /Ascent 1137 /CapHeight 686 /Descent -289 /ItalicAngle 0 /StemV 104 /XHeight 444 /FontFile3 37 0 R /CIDSet 36 0 R >>
+endobj
+38 0 obj
+<< /Length 719 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-RJDCDH-LMRoman12-Bold-0)
+%%Title: (TeX-RJDCDH-LMRoman12-Bold-0 TeX RJDCDH-LMRoman12-Bold 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (RJDCDH-LMRoman12-Bold)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-RJDCDH-LMRoman12-Bold def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+4 beginbfchar
+<001C> <0061>
+<0023> <0062>
+<002B> <0063>
+<0052> <0031>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+23 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /RJDCDH+LMRoman12-Bold /DescendantFonts [ 39 0 R ] /ToUnicode 38 0 R >>
+endobj
+39 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /RJDCDH+LMRoman12-Bold /FontDescriptor 35 0 R /W 34 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+40 0 obj
+[ 35 [ 517 ] 66 [ 239 ] 75 [ 794 ] 83 [ 639 ] 97 [ 556 ] 105 [ 361 ] 109 [ 517 ] ]
+endobj
+42 0 obj
+<< /Length 14 >>         
+[BINARY STREAM]
+endobj
+43 0 obj
+<< /Subtype /CIDFontType0C /Length 1052 >>       
+[BINARY STREAM]
+endobj
+41 0 obj
+<< /Type /FontDescriptor /FontName /ISVPDC+LMSans10-Regular /Flags 4 /FontBBox [ -420 -309 1431 1154 ] /Ascent 1154 /CapHeight 694 /Descent -309 /ItalicAngle 0 /StemV 93 /XHeight 444 /FontFile3 43 0 R /CIDSet 42 0 R >>
+endobj
+44 0 obj
+<< /Length 771 >>        
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: ProcSet (CIDInit)
+%%IncludeResource: ProcSet (CIDInit)
+%%BeginResource: CMap (TeX-ISVPDC-LMSans10-Regular-0)
+%%Title: (TeX-ISVPDC-LMSans10-Regular-0 TeX ISVPDC-LMSans10-Regular 0)
+%%Version: 1.000
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo
+<< /Registry (TeX)
+/Ordering (ISVPDC-LMSans10-Regular)
+/Supplement 0
+>> def
+/CMapName /TeX-Identity-ISVPDC-LMSans10-Regular def
+/CMapType 2 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+0 beginbfrange
+endbfrange
+7 beginbfchar
+<0023> <0062>
+<0042> <0069>
+<004B> <006D>
+<0053> <0050>
+<0061> <0053>
+<0069> <0074>
+<006D> <0075>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+15 0 obj
+<< /Type /Font /Subtype /Type0 /Encoding /Identity-H /BaseFont /ISVPDC+LMSans10-Regular /DescendantFonts [ 45 0 R ] /ToUnicode 44 0 R >>
+endobj
+45 0 obj
+<< /Type /Font /Subtype /CIDFontType0 /BaseFont /ISVPDC+LMSans10-Regular /FontDescriptor 41 0 R /W 40 0 R /CIDSystemInfo << /Registry (Adobe) /Ordering (Identity) /Supplement 0 >> >>
+endobj
+46 0 obj
+[392 ]
+endobj
+48 0 obj
+<< /Length1 1568 /Length2 967 /Length3 0 /Length 2535 >>       
+[BINARY STREAM]
+endobj
+47 0 obj
+<< /Type /FontDescriptor /FontName /GCRMMP+Dingbats /Flags 4 /FontBBox [ -1 -143 981 819 ] /Ascent 708 /CapHeight 708 /Descent 0 /ItalicAngle 0 /StemV 0 /XHeight 400 /CharSet( /a97) /FontFile 48 0 R >>
+endobj
+12 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /GCRMMP+Dingbats /FontDescriptor 47 0 R /FirstChar 123 /LastChar 123 /Widths 46 0 R >>
+endobj
+25 0 obj
+<< /Type /Pages  /Count 1 /Kids [ 6 0 R ] >>
+endobj
+49 0 obj
+<< /Type /Outlines /First 3 0 R /Last 3 0 R /Count 1 >>
+endobj
+3 0 obj
+<< /Title 4 0 R /A 1 0 R /Parent 49 0 R >>
+endobj
+50 0 obj
+<< /Names [ (Doc-Start) 22 0 R (page.1) 21 0 R (section.1) 2 0 R ] /Limits [ (Doc-Start) (section.1) ] >>
+endobj
+51 0 obj
+<< /Dests 50 0 R >>
+endobj
+52 0 obj
+<< /Type /Catalog /Pages 25 0 R /Outlines 49 0 R /Names 51 0 R /PageMode/UseOutlines/AcroForm 27 0 R /OpenAction 5 0 R >>
+endobj
+53 0 obj
+<< /Producer (LuaTeX)/Author(\376\377\000G\000r\000\374\000\337\000e\145\351\231\020\330\076\335\206)/Title(\376\377\000a\000b\000c)/Subject()/Creator(LaTeX with hyperref)/Keywords() /Trapped /False >>
+endobj
+xref
+0 54
+0000000000 65535 f 
+0000000020 00000 n 
+0000003759 00000 n 
+0000014942 00000 n 
+0000000065 00000 n 
+0000000155 00000 n 
+0000001879 00000 n 
+0000002030 00000 n 
+0000003212 00000 n 
+0000003288 00000 n 
+0000000203 00000 n 
+0000000418 00000 n 
+0000014665 00000 n 
+0000000488 00000 n 
+0000000988 00000 n 
+0000011439 00000 n 
+0000001058 00000 n 
+0000001561 00000 n 
+0000003376 00000 n 
+0000003819 00000 n 
+0000001631 00000 n 
+0000003638 00000 n 
+0000003698 00000 n 
+0000008716 00000 n 
+0000006220 00000 n 
+0000014809 00000 n 
+0000002003 00000 n 
+0000003901 00000 n 
+0000004016 00000 n 
+0000005190 00000 n 
+0000004080 00000 n 
+0000004151 00000 n 
+0000005426 00000 n 
+0000006374 00000 n 
+0000006574 00000 n 
+0000007703 00000 n 
+0000006638 00000 n 
+0000006709 00000 n 
+0000007937 00000 n 
+0000008867 00000 n 
+0000009064 00000 n 
+0000010373 00000 n 
+0000009163 00000 n 
+0000009237 00000 n 
+0000010608 00000 n 
+0000011592 00000 n 
+0000011791 00000 n 
+0000014447 00000 n 
+0000011814 00000 n 
+0000014870 00000 n 
+0000015000 00000 n 
+0000015122 00000 n 
+0000015158 00000 n 
+0000015296 00000 n 
+trailer
+<< /Size 54 /Root 52 0 R /Info 53 0 R >>
+startxref
+15514
+%%EOF

--- a/testfiles-pvt/unicode-test.pvt
+++ b/testfiles-pvt/unicode-test.pvt
@@ -1,0 +1,20 @@
+\input{regression-test}
+\documentclass{article}
+% this will will break when unicode is the default.
+% without unicode option xetex currently use auto
+% and so /Title(abc)
+% pdftex will loose the unicode and show only Grüße
+% luatex already uses unicode. 
+\usepackage{hyperref}
+
+\hypersetup{pdfauthor=Grüße早餐🦆,pdftitle={abc}}
+\begin{document}
+
+\section{\texorpdfstring{abc}{Grüße早餐🦆}}
+
+abc
+
+\begin{Form}
+\TextField[name=grüße早餐🦆,width=3cm]{}
+\end{Form}
+\end{document}

--- a/testfiles-pvt/unicode-test.tpf
+++ b/testfiles-pvt/unicode-test.tpf
@@ -1,0 +1,431 @@
+%PDF-1.5
+%ÐÔÅØ
+1 0 obj
+<< /S /GoTo /D (section.1) >>
+endobj
+4 0 obj
+(Gr\374\337e)
+endobj
+5 0 obj
+<< /S /GoTo /D [6 0 R /Fit] >>
+endobj
+10 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0 0 3.905 7.054]
+/FormType 1
+/Matrix [1 0 0 1 0 0]
+/Resources 11 0 R
+/Length 60        
+>>
+stream
+1 0 0 1 0 7.054 cm
+BT
+/F27 9.9626 Tf 0 -7.054 Td [({)]TJ
+ET
+endstream
+endobj
+11 0 obj
+<<
+/Font << /F27 12 0 R >>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+13 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0 0 36.496 13.693]
+/FormType 1
+/Matrix [1 0 0 1 0 0]
+/Resources 14 0 R
+/Length 325       
+>>
+stream
+q
+1 0 0 1 0 13.494 cm
+[]0 d 0 J 0.398 w 0 0 m 36.496 0 l S
+Q
+q
+1 0 0 1 0.199 0.398 cm
+[]0 d 0 J 0.398 w 0 0 m 0 12.896 l S
+Q
+1 0 0 1 0 13.693 cm
+BT
+/F28 9.9626 Tf 3.387 -10.306 Td [(Submit)]TJ
+ET
+q
+1 0 0 1 36.297 -13.295 cm
+[]0 d 0 J 0.398 w 0 0 m 0 12.896 l S
+Q
+q
+1 0 0 1 0 -13.494 cm
+[]0 d 0 J 0.398 w 0 0 m 36.496 0 l S
+Q
+endstream
+endobj
+14 0 obj
+<<
+/Font << /F28 15 0 R >>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+16 0 obj
+<<
+/Type /XObject
+/Subtype /Form
+/BBox [0 0 42.862 13.693]
+/FormType 1
+/Matrix [1 0 0 1 0 0]
+/Resources 17 0 R
+/Length 326       
+>>
+stream
+q
+1 0 0 1 0 13.494 cm
+[]0 d 0 J 0.398 w 0 0 m 42.862 0 l S
+Q
+q
+1 0 0 1 0.199 0.398 cm
+[]0 d 0 J 0.398 w 0 0 m 0 12.896 l S
+Q
+1 0 0 1 0 13.693 cm
+BT
+/F28 9.9626 Tf 3.387 -10.306 Td [(SubmitP)]TJ
+ET
+q
+1 0 0 1 42.662 -13.295 cm
+[]0 d 0 J 0.398 w 0 0 m 0 12.896 l S
+Q
+q
+1 0 0 1 0 -13.494 cm
+[]0 d 0 J 0.398 w 0 0 m 42.862 0 l S
+Q
+endstream
+endobj
+17 0 obj
+<<
+/Font << /F28 15 0 R >>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+20 0 obj
+<<
+/Length 133       
+>>
+stream
+BT
+/F26 14.3462 Tf 133.768 657.235 Td [(1)-1125(ab)-31(c)]TJ/F8 9.9626 Tf 0 -21.821 Td [(ab)-28(c)]TJ 169.365 -546.049 Td [(1)]TJ
+ET
+endstream
+endobj
+6 0 obj
+<<
+/Type /Page
+/Contents 20 0 R
+/Resources 19 0 R
+/MediaBox [0 0 612 792]
+/Parent 25 0 R
+/Annots [ 18 0 R ]
+>>
+endobj
+7 0 obj
+<</Type/Encoding/Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde 39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron 164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu 183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters 192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]>>
+endobj
+8 0 obj
+<</Type/Font/Subtype/Type1/Name/ZaDb/BaseFont/ZapfDingbats>>
+endobj
+9 0 obj
+<</Type/Font/Subtype/Type1/Name/Helv/BaseFont/Helvetica/Encoding 7 0 R>>
+endobj
+18 0 obj
+<<
+/Type /Annot
+/Rect [147.716 622.463 234.748 636.411]
+/Subtype/Widget/F 4/T(gr\374\337e)/FT/Tx/Q 0/BS<</W 1 /S /S>>/MK<</BC[1 0 0]/BG[1 1 1]>>/DA(/Helv 10 Tf 0 0 0 rg)/DV()/V()
+>>
+endobj
+21 0 obj
+<<
+/D [6 0 R /XYZ 132.768 705.06 null]
+>>
+endobj
+22 0 obj
+<<
+/D [6 0 R /XYZ 133.768 667.198 null]
+>>
+endobj
+2 0 obj
+<<
+/D [6 0 R /XYZ 133.768 667.198 null]
+>>
+endobj
+19 0 obj
+<<
+/Font << /F26 23 0 R /F8 24 0 R >>
+/ProcSet [ /PDF /Text ]
+>>
+endobj
+26 0 obj
+<</Fields[18 0 R]/DR<</Font<</ZaDb 8 0 R/Helv 9 0 R>>>>/DA(/Helv 10 Tf 0 g)/NeedAppearances true>>
+endobj
+27 0 obj
+[500 500 500 500 500 500 500 500 500 277.8 277.8 277.8 777.8 472.2 472.2 777.8 750 708.3 722.2 763.9 680.6 652.8 784.7 750 361.1 513.9 777.8 625 916.7 750 777.8 680.6 777.8 736.1 555.6 722.2 750 750 1027.8 750 750 611.1 277.8 500 277.8 500 277.8 277.8 500 555.6 444.4]
+endobj
+28 0 obj
+[562.5 562.5 562.5 562.5 562.5 562.5 562.5 562.5 562.5 312.5 312.5 342.6 875 531.2 531.2 875 849.5 799.8 812.5 862.3 738.4 707.2 884.3 879.6 419 581 880.8 675.9 1067.1 879.6 844.9 768.5 844.9 839.1 625 782.4 864.6 849.5 1162 849.5 849.5 687.5 312.5 581 312.5 562.5 312.5 312.5 546.9 625 500]
+endobj
+29 0 obj
+[638.9 736.1 645.8 555.6 680.6 687.5 666.7 944.5 666.7 666.7 611.1 288.9 500 288.9 500 277.8 277.8 480.6 516.7 444.4 516.7 444.4 305.6 500 516.7 238.9 266.7 488.9 238.9 794.4 516.7 500 516.7 516.7 341.7 383.3 361.1 516.7]
+endobj
+30 0 obj
+[392]
+endobj
+31 0 obj
+<<
+/Length1 1413
+/Length2 6376
+/Length3 0
+/Length 7789      
+>>
+[BINARY STREAM]
+endobj
+32 0 obj
+<<
+/Type /FontDescriptor
+/FontName /ZZSIJI+CMBX12
+/Flags 4
+/FontBBox [-53 -251 1139 750]
+/Ascent 694
+/CapHeight 686
+/Descent -194
+/ItalicAngle 0
+/StemV 109
+/XHeight 444
+/CharSet (/a/b/c/one)
+/FontFile 31 0 R
+>>
+endobj
+33 0 obj
+<<
+/Length1 1407
+/Length2 7801
+/Length3 0
+/Length 9208      
+>>
+[BINARY STREAM]
+endobj
+34 0 obj
+<<
+/Type /FontDescriptor
+/FontName /EVYFYC+CMR10
+/Flags 4
+/FontBBox [-40 -250 1009 750]
+/Ascent 694
+/CapHeight 683
+/Descent -194
+/ItalicAngle 0
+/StemV 69
+/XHeight 431
+/CharSet (/a/b/c/one)
+/FontFile 33 0 R
+>>
+endobj
+35 0 obj
+<<
+/Length1 1458
+/Length2 6860
+/Length3 0
+/Length 8318      
+>>
+[BINARY STREAM]
+endobj
+36 0 obj
+<<
+/Type /FontDescriptor
+/FontName /XYLNGW+CMSS10
+/Flags 4
+/FontBBox [-61 -250 999 759]
+/Ascent 694
+/CapHeight 694
+/Descent -194
+/ItalicAngle 0
+/StemV 78
+/XHeight 444
+/CharSet (/P/S/b/i/m/t/u)
+/FontFile 35 0 R
+>>
+endobj
+37 0 obj
+<<
+/Length1 1568
+/Length2 967
+/Length3 0
+/Length 2535      
+>>
+[BINARY STREAM]
+endobj
+38 0 obj
+<<
+/Type /FontDescriptor
+/FontName /GCRMMP+Dingbats
+/Flags 4
+/FontBBox [-1 -143 981 819]
+/Ascent 708
+/CapHeight 708
+/Descent 0
+/ItalicAngle 0
+/StemV 0
+/XHeight 400
+/CharSet (/a97)
+/FontFile 37 0 R
+>>
+endobj
+23 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /ZZSIJI+CMBX12
+/FontDescriptor 32 0 R
+/FirstChar 49
+/LastChar 99
+/Widths 28 0 R
+>>
+endobj
+24 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /EVYFYC+CMR10
+/FontDescriptor 34 0 R
+/FirstChar 49
+/LastChar 99
+/Widths 27 0 R
+>>
+endobj
+15 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /XYLNGW+CMSS10
+/FontDescriptor 36 0 R
+/FirstChar 80
+/LastChar 117
+/Widths 29 0 R
+>>
+endobj
+12 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/BaseFont /GCRMMP+Dingbats
+/FontDescriptor 38 0 R
+/FirstChar 123
+/LastChar 123
+/Widths 30 0 R
+>>
+endobj
+25 0 obj
+<<
+/Type /Pages
+/Count 1
+/Kids [6 0 R]
+>>
+endobj
+39 0 obj
+<<
+/Type /Outlines
+/First 3 0 R
+/Last 3 0 R
+/Count 1
+>>
+endobj
+3 0 obj
+<<
+/Title 4 0 R
+/A 1 0 R
+/Parent 39 0 R
+>>
+endobj
+40 0 obj
+<<
+/Names [(Doc-Start) 22 0 R (page.1) 21 0 R (section.1) 2 0 R]
+/Limits [(Doc-Start) (section.1)]
+>>
+endobj
+41 0 obj
+<<
+/Dests 40 0 R
+>>
+endobj
+42 0 obj
+<<
+/Type /Catalog
+/Pages 25 0 R
+/Outlines 39 0 R
+/Names 41 0 R
+/PageMode/UseOutlines/AcroForm 26 0 R
+/OpenAction 5 0 R
+>>
+endobj
+43 0 obj
+<<
+/Producer (pdfTeX)/Author(Gr\374\337e)/Title(abc)/Subject()/Creator(LaTeX with hyperref)/Keywords()
+/Trapped /False
+>>
+endobj
+xref
+0 44
+0000000000 65535 f 
+0000000015 00000 n 
+0000003534 00000 n 
+0000034473 00000 n 
+0000000060 00000 n 
+0000000089 00000 n 
+0000001747 00000 n 
+0000001873 00000 n 
+0000003055 00000 n 
+0000003131 00000 n 
+0000000135 00000 n 
+0000000360 00000 n 
+0000034199 00000 n 
+0000000430 00000 n 
+0000000922 00000 n 
+0000034058 00000 n 
+0000000992 00000 n 
+0000001485 00000 n 
+0000003219 00000 n 
+0000003592 00000 n 
+0000001555 00000 n 
+0000003417 00000 n 
+0000003475 00000 n 
+0000033779 00000 n 
+0000033919 00000 n 
+0000034343 00000 n 
+0000003673 00000 n 
+0000003788 00000 n 
+0000004073 00000 n 
+0000004381 00000 n 
+0000004619 00000 n 
+0000004641 00000 n 
+0000012528 00000 n 
+0000012755 00000 n 
+0000022061 00000 n 
+0000022286 00000 n 
+0000030702 00000 n 
+0000030931 00000 n 
+0000033563 00000 n 
+0000034401 00000 n 
+0000034531 00000 n 
+0000034649 00000 n 
+0000034685 00000 n 
+0000034823 00000 n 
+trailer
+<< /Size 44
+/Root 42 0 R
+/Info 43 0 R
+ >>
+startxref
+34961
+%%EOF

--- a/testfiles-xetex/unicode-test.pvt
+++ b/testfiles-xetex/unicode-test.pvt
@@ -1,0 +1,20 @@
+\input{regression-test}
+\documentclass{article}
+% this will will break when unicode is the default.
+% without unicode option xetex currently use auto
+% and so /Title(abc)
+% pdftex will loose the unicode and show only Grüße
+% luatex already uses unicode. 
+\usepackage{hyperref}
+
+\hypersetup{pdfauthor=Grüße早餐🦆,pdftitle={abc}}
+\begin{document}
+
+\section{\texorpdfstring{abc}{Grüße早餐🦆}}
+
+abc
+
+\begin{Form}
+\TextField[name=grüße早餐🦆,width=3cm]{}
+\end{Form}
+\end{document}

--- a/testfiles-xetex/unicode-test.tpf
+++ b/testfiles-xetex/unicode-test.tpf
@@ -1,0 +1,216 @@
+%PDF-1.5
+%дрнш
+15 0 obj
+<</Length 196>>
+stream
+ q 1 0 0 1 72 720 cm BT /F1 14.3462 Tf 61.768 -62.765 Td[<0052>-1000<001c0023>-31<002b>]TJ /F2 9.9626 Tf 0 -21.831 Td[<001c0023>-28<002b>]TJ ET BT /F2 9.9626 Tf 231.133 -630.635 Td[<0052>]TJ ET Q
+endstream
+endobj
+16 0 obj
+<</Font<</F1 5 0 R/F2 7 0 R>>/ProcSet[/PDF/Text/ImageC/ImageB/ImageI]>>
+endobj
+10 0 obj
+<</Type/Font/Subtype/Type1/Name/ZaDb/BaseFont/ZapfDingbats>>
+endobj
+14 0 obj
+<</Subtype/Widget/F 4/P 3 0 R/T<feff0067007200fc00df006565e99910d83edd86>/FT/Tx/Q
+0/BS<</W 1/S/S>>/MK<</BC[1 0 0]/BG[1 1 1]>>/DA(/Helv 10 Tf 0 0 0 rg)/DV()/V()/Rect[148.712
+622.343 233.752 634.298]>>
+endobj
+8 0 obj
+<</Type/Encoding/Differences[24/breve/caron/circumflex/dotaccent/hungarumlaut/ogonek/ring/tilde
+39/quotesingle 96/grave 128/bullet/dagger/daggerdbl/ellipsis/emdash/endash/florin/fraction/guilsinglleft/guilsinglright/minus/perthousand/quotedblbase/quotedblleft/quotedblright/quoteleft/quoteright/quotesinglbase/trademark/fi/fl/Lslash/OE/Scaron/Ydieresis/Zcaron/dotlessi/lslash/oe/scaron/zcaron
+164/currency 166/brokenbar 168/dieresis/copyright/ordfeminine 172/logicalnot/.notdef/registered/macron/degree/plusminus/twosuperior/threesuperior/acute/mu
+183/periodcentered/cedilla/onesuperior/ordmasculine 188/onequarter/onehalf/threequarters
+192/Agrave/Aacute/Acircumflex/Atilde/Adieresis/Aring/AE/Ccedilla/Egrave/Eacute/Ecircumflex/Edieresis/Igrave/Iacute/Icircumflex/Idieresis/Eth/Ntilde/Ograve/Oacute/Ocircumflex/Otilde/Odieresis/multiply/Oslash/Ugrave/Uacute/Ucircumflex/Udieresis/Yacute/Thorn/germandbls/agrave/aacute/acircumflex/atilde/adieresis/aring/ae/ccedilla/egrave/eacute/ecircumflex/edieresis/igrave/iacute/icircumflex/idieresis/eth/ntilde/ograve/oacute/ocircumflex/otilde/odieresis/divide/oslash/ugrave/uacute/ucircumflex/udieresis/yacute/thorn/ydieresis]>>
+endobj
+11 0 obj
+<</Type/Font/Subtype/Type1/Name/Helv/BaseFont/Helvetica/Encoding 8 0 R>>
+endobj
+9 0 obj
+[14 0 R]
+endobj
+12 0 obj
+[]
+endobj
+13 0 obj
+<</Fields 9 0 R/DR<</Font<</ZaDb 10 0 R/Helv 11 0 R>>>>/DA(/Helv 10 Tf 0 g)/CO 12 0 R/NeedAppearances
+true>>
+endobj
+18 0 obj
+<</Names[(0)17 0 R]>>
+endobj
+17 0 obj
+[3 0 R/XYZ 133.77 667.2 null]
+endobj
+19 0 obj
+<</Dests 18 0 R>>
+endobj
+21 0 obj
+<</Title<feff0047007200fc00df006565e99910d83edd86>/A<</S/GoTo/D(0)>>/Parent 20 0 R>>
+endobj
+20 0 obj
+<</First 21 0 R/Last 21 0 R/Count 1>>
+endobj
+23 0 obj
+[14 0 R]
+endobj
+3 0 obj
+<</Resources 16 0 R/Type/Page/Parent 22 0 R/Contents[15 0 R]/Annots 23 0 R>>
+endobj
+22 0 obj
+<</Type/Pages/Count 1/Kids[3 0 R]/MediaBox[0 0 612 792]>>
+endobj
+2 0 obj
+<</Creator(TeX)/Title(abc)/Author<feff0047007200fc00df006565e99910d83edd86>/Producer(xdvipdfmx)/CreationDate(D:20160520090000-00'00')>>
+endobj
+1 0 obj
+<</OpenAction[3 0 R/Fit]/PageMode/UseOutlines/AcroForm 13 0 R/Names 19 0 R/Outlines
+20 0 R/Pages 22 0 R/Type/Catalog>>
+endobj
+24 0 obj
+<</Length 395>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /EXQIVM+LMRoman12-Bold-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+4 beginbfchar
+<001C> <0061>
+<0023> <0062>
+<002B> <0063>
+<0052> <0031>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+25 0 obj
+<</Length 398>>
+stream
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CMapName /XUUPUX+LMRoman10-Regular-UTF16 def
+/CMapType 2 def
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+4 beginbfchar
+<001C> <0061>
+<0023> <0062>
+<002B> <0063>
+<0052> <0031>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+endstream
+endobj
+27 0 obj
+<</Subtype/CIDFontType0C/Length 880>>
+[BINARY STREAM]
+endobj
+28 0 obj
+[28[547]35[625]43[500]82[563]]
+endobj
+29 0 obj
+<</Length 11>>
+[BINARY STREAM]
+endobj
+4 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/EXQIVM+LMRoman12-Bold/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 26 0 R/DW 280/W 28 0 R>>
+endobj
+26 0 obj
+<</Type/FontDescriptor/Ascent 806/Descent -194/StemV 109/CapHeight 806/AvgWidth 618/FontBBox[-476
+-289 1577 1137]/ItalicAngle 0/Flags 262150/Style<</Panose<000000000800000000000000>>>/FontName/EXQIVM+LMRoman12-Bold/FontFile3
+27 0 R/CIDSet 29 0 R>>
+endobj
+31 0 obj
+<</Subtype/CIDFontType0C/Length 929>>
+[BINARY STREAM]
+endobj
+32 0 obj
+[28[500]35[556]43[444]82[500]]
+endobj
+33 0 obj
+<</Length 11>>
+[BINARY STREAM]
+endobj
+6 0 obj
+<</Type/Font/Subtype/CIDFontType0/BaseFont/XUUPUX+LMRoman10-Regular/CIDSystemInfo<</Registry(Adobe)/Ordering(Identity)/Supplement
+0>>/FontDescriptor 30 0 R/DW 280/W 32 0 R>>
+endobj
+30 0 obj
+<</Type/FontDescriptor/Ascent 806/Descent -194/StemV 69/CapHeight 806/AvgWidth 549/FontBBox[-430
+-290 1417 1127]/ItalicAngle 0/Flags 6/Style<</Panose<000000000500000000000000>>>/FontName/XUUPUX+LMRoman10-Regular/FontFile3
+31 0 R/CIDSet 33 0 R>>
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/EXQIVM+LMRoman12-Bold-Identity-H/Encoding/Identity-H/DescendantFonts[4 0 R]/ToUnicode
+24 0 R>>
+endobj
+7 0 obj
+<</Type/Font/Subtype/Type0/BaseFont/XUUPUX+LMRoman10-Regular-Identity-H/Encoding/Identity-H/DescendantFonts[6 0 R]/ToUnicode
+25 0 R>>
+endobj
+xref
+0 34
+0000000000 65535 f 
+0000002696 00000 n 
+0000002545 00000 n 
+0000002379 00000 n 
+0000004782 00000 n 
+0000006790 00000 n 
+0000006340 00000 n 
+0000006936 00000 n 
+0000000642 00000 n 
+0000001913 00000 n 
+0000000349 00000 n 
+0000001824 00000 n 
+0000001937 00000 n 
+0000001956 00000 n 
+0000000426 00000 n 
+0000000015 00000 n 
+0000000261 00000 n 
+0000002119 00000 n 
+0000002081 00000 n 
+0000002165 00000 n 
+0000002300 00000 n 
+0000002199 00000 n 
+0000002471 00000 n 
+0000002354 00000 n 
+0000002830 00000 n 
+0000003275 00000 n 
+0000004968 00000 n 
+0000003723 00000 n 
+0000004675 00000 n 
+0000004722 00000 n 
+0000006529 00000 n 
+0000005232 00000 n 
+0000006233 00000 n 
+0000006280 00000 n 
+trailer
+<</Root 1 0 R/Info 2 0 R/ID[<ID-STRING><ID-STRING>]/Size
+34>>
+startxref
+7085
+%%EOF


### PR DESCRIPTION
older version of xdvipdfmx assumed that a number of strings where in UTF-8 and and issued a warning when encountering the default UTF16-BE from hyperref. To avoid the warning hyperref had code in various places to convert strings back from UTF16-BE back to UTF-8 so that xdvipdfmx could then convert this to UTF16-BE again without complaining. 

With newer xdvipdfmx this is no longer needed so the code has been removed. 