### PR TITLE
Some fixes in French translations

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -5564,13 +5564,13 @@
   \def\pageautorefname{page}%
 }
 \def\HyLang@french{%
-  \def\equationautorefname{\'Equation}%
+  \def\equationautorefname{\'equation}%
   \def\footnoteautorefname{note}%
   \def\itemautorefname{item}%
-  \def\figureautorefname{Figure}%
-  \def\tableautorefname{Tableau}%
-  \def\partautorefname{Partie}%
-  \def\appendixautorefname{Annexe}%
+  \def\figureautorefname{figure}%
+  \def\tableautorefname{tableau}%
+  \def\partautorefname{partie}%
+  \def\appendixautorefname{annexe}%
   \def\chapterautorefname{chapitre}%
   \def\sectionautorefname{section}%
   \def\subsectionautorefname{sous-section}%
@@ -5578,7 +5578,7 @@
   \def\paragraphautorefname{paragraphe}%
   \def\subparagraphautorefname{sous-paragraphe}%
   \def\FancyVerbLineautorefname{ligne}%
-  \def\theoremautorefname{Th\'eor\`eme}%
+  \def\theoremautorefname{th\'eor\`eme}%
   \def\pageautorefname{page}%
 }
 \def\HyLang@german{%

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -5570,7 +5570,7 @@
   \def\figureautorefname{Figure}%
   \def\tableautorefname{Tableau}%
   \def\partautorefname{Partie}%
-  \def\appendixautorefname{Appendice}%
+  \def\appendixautorefname{Annexe}%
   \def\chapterautorefname{chapitre}%
   \def\sectionautorefname{section}%
   \def\subsectionautorefname{sous-section}%


### PR DESCRIPTION
This fixes may break existing documents but in a harmless way and, IMHO, it is worth it. 

As said in a commit message, in French ref names are not capitalized words, but note they are capitalized at the beginning of sentences. Hence, it would be worth to add a way to distinguish capitalized and non-capitalized words.
