### PR TITLE
fix issue #8

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -11182,6 +11182,17 @@
     \fi
     \@tempa
   }%
+  % CodeA: define  macro which puts hyperanchor.
+  \def\amsthm@@hyperanchor{%
+    \Hy@raisedlink{%
+          \hyper@anchorstart{%
+            \ltx@ifundefined{Hy@dth@currentHref}%
+            \@currentHref\Hy@dth@currentHref
+          }\hyper@anchorend
+        }%
+      }%
+   % CodeB: define macro which executes CodeA once
+    \def\amsthm@hyperanchor{\amsthm@@hyperanchor\let\amsthm@@hyperanchor\relax}%
   \ifx\Hy@temp\@thm
     \def\@thm#1#2#3{%
       \ifhmode
@@ -11240,6 +11251,8 @@
         \H@refstepcounter{#2}%
         \hyper@makecurrent{#2}%
         \let\Hy@dth@currentHref\@currentHref
+        % execute CodeB (will place CodeA)
+        \amsthm@hyperanchor
         \def\@tempa{%
           \@oparg{\@begintheorem{#3}{\csname the#2\endcsname}}[]%
         }%
@@ -11261,12 +11274,8 @@
       \endgroup
       \ifx\@empty\dth@counter
       \else
-        \Hy@raisedlink{%
-          \hyper@anchorstart{%
-            \ltx@ifundefined{Hy@dth@currentHref}%
-            \@currentHref\Hy@dth@currentHref
-          }\hyper@anchorend
-        }%
+        % execute CodeB (will place CodeA)
+        \amsthm@hyperanchor
       \fi
       \unhbox\@labels
     \fi

--- a/testfiles/issue8-amsart-itemize.lvt
+++ b/testfiles/issue8-amsart-itemize.lvt
@@ -1,0 +1,27 @@
+\input regression-test\relax
+\documentclass{amsart}
+\usepackage[verbose=true]{hyperref}
+\newtheorem{example}{Example}
+
+\begin{document}
+
+\START
+
+\BEGINTEST{amsart, theorem head + itemize item inline}
+\begin{example}\label{ex}
+\begin{itemize}
+\item
+\end{itemize}
+\end{example}
+\ENDTEST
+
+\BEGINTEST{amsart, theorem head + itemize item on separate line}
+\begin{example}\label{ex2} X
+\begin{itemize}
+\item
+\end{itemize}
+\end{example}
+\ENDTEST
+
+\END
+\end{document}

--- a/testfiles/issue8-amsart-itemize.tlg
+++ b/testfiles/issue8-amsart-itemize.tlg
@@ -1,0 +1,12 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: amsart, theorem head + itemize item inline
+============================================================
+Package hyperref Info: Anchor `example.1' on input line ....
+============================================================
+============================================================
+TEST 2: amsart, theorem head + itemize item on separate line
+============================================================
+Package hyperref Info: Anchor `example.2' on input line ....
+============================================================

--- a/testfiles/issue8-amsthm-enumerate.lvt
+++ b/testfiles/issue8-amsthm-enumerate.lvt
@@ -1,0 +1,28 @@
+\input regression-test\relax
+\documentclass{article}
+\usepackage{amsthm}
+\usepackage[verbose=true]{hyperref}
+\newtheorem{theorem}{Theorem}[section]
+\begin{document}
+
+\START
+
+\BEGINTEST{amsthm, theorem head + enumerate item inline}
+\begin{theorem}\label{th1}
+\begin{enumerate}
+\item
+\end{enumerate}
+\end{theorem}
+\ENDTEST
+
+\BEGINTEST{amsthm, theorem head + enumerate item on separate line}
+\begin{theorem}\label{th2} X
+\begin{enumerate}
+\item
+\end{enumerate}
+\end{theorem}
+\ENDTEST
+
+\END
+
+\end{document}

--- a/testfiles/issue8-amsthm-enumerate.tlg
+++ b/testfiles/issue8-amsthm-enumerate.tlg
@@ -1,0 +1,14 @@
+This is a generated file for the l3build validation system.
+Don't change this file in any respect.
+============================================================
+TEST 1: amsthm, theorem head + enumerate item inline
+============================================================
+Package hyperref Info: Anchor `theorem.0.1' on input line ....
+Package hyperref Info: Anchor `Item.1' on input line ....
+============================================================
+============================================================
+TEST 2: amsthm, theorem head + enumerate item on separate line
+============================================================
+Package hyperref Info: Anchor `theorem.0.2' on input line ....
+Package hyperref Info: Anchor `Item.2' on input line ....
+============================================================


### PR DESCRIPTION
 - fix error when combining hyperref, amsart and
   itemize within theorem #8
 - same error with article, amsthm, and enumerate within theorem
 - add 2 test cases:
   1. amsart + theorem + itemize
   2. article + amsthm + theorem + enumerate