### PR TITLE
Implement 'uncolored' setting for listtoc option 

### DIFF
--- a/doc/hyperref-doc.tex
+++ b/doc/hyperref-doc.tex
@@ -881,7 +881,7 @@ hyperindex     & boolean & true    & Makes the page numbers of index entries int
 hyperfootnotes & boolean & true    & Makes the footnote marks into hyperlinks to the footnote text.
                                      Easily broken \ldots\\
 encap          &         &         & Sets encap character for hyperindex \\
-linktoc        & text    & section & make text (\verb|section|), page number (\verb|page|), both (\verb|all|) or nothing (\verb|none|) be link on TOC, LOF and LOT \\
+	linktoc        & text    & section & make text (\verb|section|), page number (\verb|page|), both (\verb|all|), both, but with no change in text color (\verb|uncolored|) or nothing (\verb|none|) be link on TOC, LOF and LOT \\
 linktocpage    & boolean & false   & make page number, not text, be link on TOC, LOF and LOT \\
 breaklinks     & boolean & false   & allow links to break over lines by making links over multiple lines into PDF links to
                                      the same target \\
@@ -2057,10 +2057,11 @@ an anchor name which can be referenced with a bookmark command.
  The new option `linktoc' allows more control which part
   of an entry in the table of contents is made into a link:
 \begin{itemize}
- \item `linktoc=none'    (no links)
- \item `linktoc=section' (default behaviour, same as `linktocpage=false')
- \item `linktoc=page'    (same as `linktocpage=true')
- \item `linktoc=all'     (both the section and page part are links)
+ \item `linktoc=none'      (no links)
+ \item `linktoc=section'   (default behaviour, same as `linktocpage=false')
+ \item `linktoc=page'      (same as `linktocpage=true')
+ \item `linktoc=all'       (both the section and page part are links)
+ \item `linktoc=uncolored' (both the section and page part are links, but are rendered in the default text color. Useful if tables of contents pages may have differing color schemes throughout a document)
 \end{itemize}
 
 \subsection{Option `pdfnewwindow' changed}

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -16767,7 +16767,7 @@
 \def\@urltype{url}
 \def\hyper@linkstart#1#2{%
   \Hy@VerboseLinkStart{#1}{#2}%
-    {\expandafter\Hy@colorlink\csname @#1color\endcsname}
+  \expandafter\Hy@colorlink\csname @#1color\endcsname
   \def\Hy@tempa{#1}%
   \ifx\Hy@tempa\@urltype
     \special{html:<a href=\hyper@quote#2\hyper@quote>}%

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -893,7 +893,6 @@
 \fi
 \Hy@pdfusetitlefalse
 \Hy@verbosefalse
-%\Hy@verbosetrue
 \Hy@pdfwindowuitrue
 \Hy@pdfdisplaydoctitlefalse
 \Hy@pdfafalse

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -893,6 +893,7 @@
 \fi
 \Hy@pdfusetitlefalse
 \Hy@verbosefalse
+%\Hy@verbosetrue
 \Hy@pdfwindowuitrue
 \Hy@pdfdisplaydoctitlefalse
 \Hy@pdfafalse
@@ -12052,9 +12053,13 @@
     \else % uncolored
       \def\Hy@temp{#3}%
       \ifx\Hy@temp\ltx@empty
-        \csname l@#1\endcsname{#2}{#3}%
+        \csname l@#1\endcsname{%
+          \hyper@linkstart{uncoloredlink}{\Hy@tocdestname}{#2}\hyper@linkend
+        }{}%
       \else
-        \csname l@#1\endcsname{{#2}}{%
+        \csname l@#1\endcsname{%
+          \hyper@linkstart{uncoloredlink}{\Hy@tocdestname}{#2}\hyper@linkend
+        }{%
           \hyper@linkstart{uncoloredlink}{\Hy@tocdestname}{#3}\hyper@linkend
         }%
       \fi
@@ -16763,12 +16768,6 @@
 \def\@urltype{url}
 \def\hyper@linkstart#1#2{%
   \Hy@VerboseLinkStart{#1}{#2}%
- \ifnum\pdf@strcmp{\unexpanded{#1}}{uncoloredlink}=0 %
-     \expandafter\@firstoftwo
-  \else
-    \expandafter\@secondoftwo
-  \fi
-    {} % uncolored link does nothing
     {\expandafter\Hy@colorlink\csname @#1color\endcsname}
   \def\Hy@tempa{#1}%
   \ifx\Hy@tempa\@urltype

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -4682,6 +4682,7 @@
 \chardef\Hy@linktoc@section=1 %
 \chardef\Hy@linktoc@page=2 %
 \chardef\Hy@linktoc@all=3 %
+\chardef\Hy@linktoc@uncolored=4 %
 \ifHy@linktocpage
   \let\Hy@linktoc\Hy@linktoc@page
 \else
@@ -4692,7 +4693,7 @@
     \Hy@Warning{%
       Unexpected value `#1' of\MessageBreak
       option `linktoc' instead of `none',\MessageBreak
-      `section', `page' or `all'%
+      `section', `page', 'uncolored' or `all'%
     }%
   }{%
     \expandafter\let\expandafter\Hy@linktoc
@@ -12034,8 +12035,8 @@
         \csname l@#1\endcsname{{#2}}{%
           \hyper@linkstart{link}{\Hy@tocdestname}{#3}\hyper@linkend
         }%
-      \fi
-    \else % all
+        \fi        
+    \or % all
       \def\Hy@temp{#3}%
       \ifx\Hy@temp\ltx@empty
         \csname l@#1\endcsname{%
@@ -12046,6 +12047,15 @@
           \hyper@linkstart{link}{\Hy@tocdestname}{#2}\hyper@linkend
         }{%
           \hyper@linkstart{link}{\Hy@tocdestname}{#3}\hyper@linkend
+        }%
+      \fi
+    \else % uncolored
+      \def\Hy@temp{#3}%
+      \ifx\Hy@temp\ltx@empty
+        \csname l@#1\endcsname{#2}{#3}%
+      \else
+        \csname l@#1\endcsname{{#2}}{%
+          \hyper@linkstart{uncoloredlink}{\Hy@tocdestname}{#3}\hyper@linkend
         }%
       \fi
     \fi
@@ -16753,7 +16763,13 @@
 \def\@urltype{url}
 \def\hyper@linkstart#1#2{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \expandafter\Hy@colorlink\csname @#1color\endcsname
+ \ifnum\pdf@strcmp{\unexpanded{#1}}{uncoloredlink}=0 %
+     \expandafter\@firstoftwo
+  \else
+    \expandafter\@secondoftwo
+  \fi
+    {} % uncolored link does nothing
+    {\expandafter\Hy@colorlink\csname @#1color\endcsname}
   \def\Hy@tempa{#1}%
   \ifx\Hy@tempa\@urltype
     \special{html:<a href=\hyper@quote#2\hyper@quote>}%


### PR DESCRIPTION
For the MEGA65 User Guide (https://github.com/mega65/mega65-user-guide), we have TOCs that appear in different colour schemes (black text on white background and white text on black background).  No single override of the link colour is suitable for this.  We wished to simply be able to leave the text colour unchanged, but still be linked.  

This pull request implements this functionality in hyperref in a very minimal way, by creating an option 'uncolored' for listtoc, which mimics 'all', but because no colours for uncolored links are defined, it defaults to using the current text colour, i.e., exactly what we were seeking. 