### PR TITLE
Added support for Italian language in backref.dtx

### DIFF
--- a/backref.dtx
+++ b/backref.dtx
@@ -408,6 +408,13 @@
   \def\backrefsep{, }%
   \def\backreftwosep{ en~}%
   \def\backreflastsep{ en~}%
+}
+\def\backrefitalian{%
+  \def\backrefpagesname{pagine}%
+  \def\backrefsectionsname{sezioni}%
+  \def\backrefsep{, }%
+  \def\backreftwosep{ e~}%
+  \def\backreflastsep{ e~}%
 }%
 %    \end{macrocode}
 %    Instead of package babel's definition of \cmd{\addto} the
@@ -465,6 +472,7 @@
 \BR@DeclareLang{brazil}{brazil}
 \BR@DeclareLang{brazilian}{brazil}
 \BR@DeclareLang{afrikaans}{afrikaans}
+\BR@DeclareLang{italian}{italian}
 %    \end{macrocode}
 %    Default is the english version:
 %    \begin{macrocode}


### PR DESCRIPTION
Implementation linked to [this post](https://tex.stackexchange.com/questions/675648/how-to-set-italian-as-language-for-hyperrefs-backref-option-in-moderncv/675649#675649).