### PR TITLE
remove dependency on `etexcmds` package

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+2023-02-19 Yukai Chou
+    * remove dependency on etexcmds package
+
 2023-02-05 Ulrike Fischer/David Carlisle
     * if babel is loaded casing with \MakeUppercase and \MakeLowercase
       respects the rules of the current locale/language in the bookmarks.

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -3123,16 +3123,6 @@
 %
 % \subsubsection{Protecting spaces}
 %
-%    \begin{macrocode}
-\RequirePackage{etexcmds}[2007/09/09]
-\ifetex@unexpanded
-  \expandafter\@secondoftwo
-\else
-  \expandafter\@firstoftwo
-\fi
-{%
-%    \end{macrocode}
-%
 %    \begin{macro}{\HyPsd@ProtectSpaces}
 %    \cs{HyPsd@ProtectSpaces} calls with the expanded
 %    string \cs{HyPsd@@ProtectSpacesFi}. The expanded string is
@@ -3141,27 +3131,30 @@
 %    at the beginning or end of the string and grouping characters
 %    are not removed by the call of \cs{HyPsd@@ProtectSpacesFi}.
 %    \begin{macrocode}
-  \def\HyPsd@ProtectSpaces#1{%
+\let\HyPsd@fi\fi
+\def\HyPsd@ProtectSpaces#1{%
+  \xdef#1{%
     \iftrue
       \expandafter\HyPsd@@ProtectSpacesFi
-        \expandafter|\expandafter\@empty#1| \HyPsd@End#1%
-    \fi
+        \expandafter|\expandafter\@empty#1| %
+    \HyPsd@fi
   }%
+  \expandafter\HyPsd@RemoveMask#1\HyPsd@End#1%
+}%
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\HyPsd@@ProtectSpacesFi}
 %    The string can contain command tokens, so it is better
 %    to use an \cs{def} instead of an \cs{edef}.
 %    \begin{macrocode}
-  \def\HyPsd@@ProtectSpacesFi#1 #2\HyPsd@End#3\fi{%
-    \fi
-    \ifx\scrollmode#2\scrollmode
-      \HyPsd@RemoveMask#1\HyPsd@End#3%
-    \else
-      \gdef#3{#1\HyPsd@UnexpandableSpace#2}%
-      \expandafter\HyPsd@@ProtectSpacesFi#3\HyPsd@End#3%
-    \fi
-  }%
+\def\HyPsd@@ProtectSpacesFi#1 #2\HyPsd@fi{%
+  \fi
+  \unexpanded{#1}%
+  \ifx\scrollmode#2\scrollmode
+  \else
+    \HyPsd@@ProtectSpacesFi\HyPsd@UnexpandableSpace#2%
+  \HyPsd@fi
+}%
 %    \end{macrocode}
 %    \end{macro}
 %
@@ -3171,38 +3164,11 @@
 %    It is used by \cs{HyPsd@@ProtectSpacesFi} and by the code in
 %    \cs{pdfstringdef} that removes the grouping chararcters.
 %    \begin{macrocode}
-  \def\HyPsd@RemoveMask|#1|\HyPsd@End#2{%
-    \toks@\expandafter{#1}%
-    \xdef#2{\the\toks@}%
-  }%
+\def\HyPsd@RemoveMask|#1|\HyPsd@End#2{%
+  \xdef#2{\unexpanded\expandafter{#1}}%
+}%
 %    \end{macrocode}
 %    \end{macro}
-%
-%    \begin{macrocode}
-}{%
-  \let\HyPsd@fi\fi
-  \def\HyPsd@ProtectSpaces#1{%
-    \xdef#1{%
-      \iftrue
-        \expandafter\HyPsd@@ProtectSpacesFi
-          \expandafter|\expandafter\@empty#1| %
-      \HyPsd@fi
-    }%
-    \expandafter\HyPsd@RemoveMask#1\HyPsd@End#1%
-  }%
-  \def\HyPsd@@ProtectSpacesFi#1 #2\HyPsd@fi{%
-    \fi
-    \etex@unexpanded{#1}%
-    \ifx\scrollmode#2\scrollmode
-    \else
-      \HyPsd@@ProtectSpacesFi\HyPsd@UnexpandableSpace#2%
-    \HyPsd@fi
-  }%
-  \def\HyPsd@RemoveMask|#1|\HyPsd@End#2{%
-    \xdef#2{\etex@unexpanded\expandafter{#1}}%
-  }%
-}
-%    \end{macrocode}
 %
 % \subsubsection{Remove grouping braces}
 %    \begin{macro}{\HyPsd@RemoveBraces}


### PR DESCRIPTION
Just a blind deletion and movement of related code lines.

To be honest I didn't put time to read nor fully understand if the corresponding doc still describes the behavior of code well.

Locally tested with `l3build check`, only the two pdf-based tests with config `build-xetex.lua` fails due to different `/CreationDate` and the first part of font name(s).