### PR TITLE
remove ltxcmds dependency

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,7 @@
+2023-11-14 Ulrike Fischer
+	* remove ltxcmds dependency in hluatex.dtx
+	* remove ltxcmds dependency in nameref.dtx (v2.55)
+
 2023-11-11 David Carlisle
         * remove ltxcmds dependency
 	

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+2023-11-11 David Carlisle
+        * remove ltxcmds dependency
+	
 2023-11-07 Ulrike Fischer
 	* improve thm code, issue 304
 	* insert socket for varwidth, issue 204 and 293

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,6 +1,7 @@
 2023-11-14 Ulrike Fischer
 	* remove ltxcmds dependency in hluatex.dtx
 	* remove ltxcmds dependency in nameref.dtx (v2.55)
+	* remove ltxcmds dependency in backref.dtx (v1.44)
 
 2023-11-11 David Carlisle
         * remove ltxcmds dependency

--- a/backref.dtx
+++ b/backref.dtx
@@ -32,7 +32,7 @@
 %<driver>\ProvidesFile{backref.drv}
 % \fi
 % \ProvidesFile{backref.dtx}
-  [2023-08-01 v1.43 Bibliographical back referencing]%
+  [2023-14-11 v1.44 Bibliographical back referencing]%
 %
 %
 % \iffalse
@@ -304,7 +304,6 @@
 %    \begin{macrocode}
 \RequirePackage{kvoptions}[2011/06/30]
 \RequirePackage{kvsetkeys}[2009/07/30]
-\RequirePackage{ltxcmds}[2009/12/12]
 \SetupKeyvalOptions{%
   family=backref,%
   prefix=BR@,%
@@ -321,7 +320,7 @@
 %    default for the verbose switch.
 %    \begin{macrocode}
 \DeclareBoolOption[%
-  \ltx@ifundefined{ifHy@verbose}{%
+  \@ifundefined{ifHy@verbose}{%
     false%
   }{%
     \ifx\ifHy@verbose\iftrue true\else false\fi

--- a/hluatex.dtx
+++ b/hluatex.dtx
@@ -66,7 +66,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \pdf@ifdraftmode{%
-  \let\Hy@PutCatalog\ltx@gobble
+  \let\Hy@PutCatalog\@gobble
 }{%
   \let\Hy@PutCatalog\pdfcatalog
 }
@@ -105,7 +105,7 @@
       |ifx|\#2|\%%
       |else
         \\%
-        |ltx@ReturnAfterFi{%
+        |Hy@ReturnAfterFi{%
           |Hy@ExchangeBackslash#2|@nil
         }%
       |fi
@@ -116,7 +116,7 @@
     \ifx\\#2\\%
     \else
       \@backslashchar(%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@ExchangeLeftParenthesis#2\@nil
       }%
     \fi
@@ -126,7 +126,7 @@
     \ifx\\#2\\%
     \else
       \@backslashchar)%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@ExchangeRightParenthesis#2\@nil
       }%
     \fi
@@ -156,7 +156,7 @@
   \fi
   \ifHy@setpdfversion
     \ifnum\Hy@pdf@majorminor@version<105 %
-      \ltx@IfUndefined{pdfobjcompresslevel}{%
+      \@ifundefined{pdfobjcompresslevel}{%
       }{%
         \ifHy@verbose
           \Hy@InfoNoLine{%
@@ -166,19 +166,19 @@
             \Hy@pdf@majorversion.\Hy@pdf@minorversion
           }%
         \fi
-        \pdfobjcompresslevel=\ltx@zero
+        \pdfobjcompresslevel=\z@
       }%
     \fi
     \ifnum\Hy@pdfmajorminor@version=\Hy@pdf@majorminor@version\relax
     \else
-      \let\Hy@temp\ltx@empty
+      \let\Hy@temp\@empty
       \def\Hy@temp@A#1#2{%
-        \ifnum#1>\ltx@zero
+        \ifnum#1>\z@
           \edef\Hy@temp{%
             \Hy@temp
             \space\space
             \the#1\space #2%
-            \ifnum#1=\ltx@one\else s\fi
+            \ifnum#1=\@ne\else s\fi
             \MessageBreak
           }%
         \fi
@@ -187,15 +187,15 @@
       \Hy@temp@A\lastsavedboxresourceindex{form XObject}%
       \Hy@temp@A\lastsavedimageresourceindex{image XObject}%
       \Hy@temp@A\pdflastannot{annotation}%
-      \ltx@IfUndefined{pdflastlink}{%
+      \@ifundefined{pdflastlink}{%
       }{%
          \Hy@temp@A\pdflastlink{link}%
       }%
-      \ifx\Hy@temp\ltx@empty
+      \ifx\Hy@temp\@empty
         \Hy@pdfmajorversion=\Hy@pdf@majorversion\relax
         \Hy@pdfminorversion=\Hy@pdf@minorversion\relax
       \else
-        \let\Hy@temp@A\ltx@empty
+        \let\Hy@temp@A\@empty
         \ifnum\Hy@pdf@majorminor@version=104 %
           \IfFileExists{pdf14.sty}{%
             \def\Hy@temp@A{%
@@ -218,7 +218,7 @@
           \expandafter\string\Hy@pdfminorversion=\Hy@pdf@minorversion
           \string\relax
           \ifnum\Hy@pdf@majorminor@version<105 %
-            \ltx@ifundefined{pdfobjcompresslevel}{%
+            \@ifundefined{pdfobjcompresslevel}{%
             }{%
               \MessageBreak
               \space\space
@@ -426,7 +426,7 @@
 }
 \def\hyper@linkstart#1#2{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{\csname @#1bordercolor\endcsname}%
@@ -436,7 +436,7 @@
 \def\hyper@linkend{\close@pdflink}
 \def\hyper@link#1#2#3{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{\csname @#1bordercolor\endcsname}%
@@ -742,7 +742,7 @@
         \fi
       \fi
     }{%
-      \ltx@IfUndefined{stockwidth}{%
+      \@ifundefined{stockwidth}{%
         \ifdim\paperwidth>\z@
           \setlength{\pagewidth}{\paperwidth}%
         \fi
@@ -813,8 +813,8 @@
     \the\lastsavedboxresourceindex\space 0 R%
   }%
 }%
-\let\HyField@afields\ltx@empty
-\let\HyField@cofields\ltx@empty
+\let\HyField@afields\@empty
+\let\HyField@cofields\@empty
 \begingroup\expandafter\expandafter\expandafter\endgroup
 \expandafter\ifx\csname pdflastlink\endcsname\relax
   \let\HyField@AddToFields\relax
@@ -826,37 +826,37 @@
     but other PDF viewers might complain%
   }%
 \else
-  \let\HyField@AuxAddToFields\ltx@gobble
-  \let\HyField@AuxAddToCoFields\ltx@gobbletwo
+  \let\HyField@AuxAddToFields\@gobble
+  \let\HyField@AuxAddToCoFields\@gobbletwo
   \def\HyField@AfterAuxOpen{\Hy@AtBeginDocument}%
   \def\HyField@ABD@AuxAddToCoFields#1#2{%
     \begingroup
       \Hy@safe@activestrue
-      \let\ltx@secondoftwo\relax
-      \ifx\HyField@cofields\ltx@empty
+      \let\@secondoftwo\relax
+      \ifx\HyField@cofields\@empty
         \xdef\HyField@cofields{%
-          \ltx@secondoftwo{#1}{ #2 0 R}%
+          \@secondoftwo{#1}{ #2 0 R}%
         }%
       \else
-        \let\ltx@secondoftwo\relax
+        \let\@secondoftwo\relax
         \def\HyField@AddCoField##1##2##3{%
-          \ifx##1\ltx@empty
-            \ltx@secondoftwo{#1}{ #2 0 R}%
-            \expandafter\ltx@gobble
+          \ifx##1\@empty
+            \@secondoftwo{#1}{ #2 0 R}%
+            \expandafter\@gobble
           \else
-            \ifnum\pdf@strcmp{##2}{#1}>\ltx@zero
-              \ltx@secondoftwo{#1}{ #2 0 R}%
-              \ltx@secondoftwo{##2}{##3}%
-              \expandafter\expandafter\expandafter\ltx@gobble
+            \ifnum\pdf@strcmp{##2}{#1}>\z@
+              \@secondoftwo{#1}{ #2 0 R}%
+              \@secondoftwo{##2}{##3}%
+              \expandafter\expandafter\expandafter\@gobble
             \else
-              \ltx@secondoftwo{##2}{##3}%
+              \@secondoftwo{##2}{##3}%
             \fi
           \fi
           \HyField@AddCoField
         }%
         \xdef\HyField@cofields{%
           \expandafter\HyField@AddCoField
-          \HyField@cofields\ltx@empty\ltx@empty\ltx@empty
+          \HyField@cofields\@empty\@empty\@empty
         }%
       \fi
     \endgroup
@@ -887,7 +887,7 @@
     \expandafter\HyField@@AddToFields\expandafter{%
       \the\pdflastlink
     }%
-    \ifx\Fld@calculate@code\ltx@empty
+    \ifx\Fld@calculate@code\@empty
     \else
       \begingroup
         \Hy@safe@activestrue
@@ -928,7 +928,7 @@
       \immediate\pdfobj{%
         <<%
           /Fields[\HyField@afields]%
-          \ifx\HyField@cofields\ltx@empty
+          \ifx\HyField@cofields\@empty
           \else
             /CO[\romannumeral-`\Q\HyField@cofields]%
           \fi
@@ -968,16 +968,16 @@
     \fbox{\textcolor{yellow}{\textsf{SubmitP}}}%
   }{SubmitP}%
 }
-\let\@endForm\ltx@empty
-\let\HyAnn@AbsPageLabel\ltx@empty
-\let\Fld@pageobjref\ltx@empty
-\ltx@IfUndefined{pdfpageref}{%
+\let\@endForm\@empty
+\let\HyAnn@AbsPageLabel\@empty
+\let\Fld@pageobjref\@empty
+\@ifundefined{pdfpageref}{%
 }{%
-  \ltx@ifpackageloaded{zref-abspage}{%
+  \@ifpackageloaded{zref-abspage}{%
     \newcount\HyAnn@Count
-    \HyAnn@Count=\ltx@zero
+    \HyAnn@Count=\z@
     \def\HyAnn@AbsPageLabel{%
-      \global\advance\HyAnn@Count by\ltx@one
+      \global\advance\HyAnn@Count by\@ne
       \zref@labelbyprops{HyAnn@\the\HyAnn@Count}{abspage}%
       \zref@refused{HyAnn@\the\HyAnn@Count}%
     }%
@@ -997,7 +997,7 @@
 }
 \def\@TextField[#1]#2{% parameters, label
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \let\Fld@value\@empty
   \def\Fld@width{\DefaultWidthofText}%
   \def\Fld@height{%
@@ -1317,7 +1317,7 @@
     \else
       \expandafter
       \Hy@pstringdef\csname Hy@esc@\string#2\endcsname{#2}%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@@escapeform#3\@nil
       }%
     \fi
@@ -1750,9 +1750,9 @@
   \def\HyPsd@SanitizeOut@BraceLeft#1(#2\@nil{%
     #1%
     \ifx\\#2\\%
-      \expandafter\ltx@gobble
+      \expandafter\@gobble
     \else
-      \expandafter\ltx@firstofone
+      \expandafter\@firstofone
     \fi
     {%
       \string\173%
@@ -1762,9 +1762,9 @@
   \def\HyPsd@SanitizeOut@BraceRight#1)#2\@nil{%
     #1%
     \ifx\\#2\\%
-      \expandafter\ltx@gobble
+      \expandafter\@gobble
     \else
-      \expandafter\ltx@firstofone
+      \expandafter\@firstofone
     \fi
     {%
       \string\175%
@@ -1913,7 +1913,7 @@
   \endgroup
   \H@old@schapter{#1}%
 }
-\ltx@IfUndefined{@chapter}{}{%
+\@ifundefined{@chapter}{}{%
   \let\Hy@org@chapter\@chapter
   \def\@chapter{%
     \def\Hy@next{%
@@ -1923,7 +1923,7 @@
       }%
     }%
     \ifnum\c@secnumdepth>\m@ne
-      \ltx@IfUndefined{if@mainmatter}%
+      \@ifundefined{if@mainmatter}%
       \iftrue{\csname if@mainmatter\endcsname}%
         \let\Hy@next\relax
       \fi

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -51,7 +51,7 @@
 %<puvnenc>\ProvidesFile{puvnenc.def}
 %<puarenc>\ProvidesFile{puarenc.def}
 %<psdextra>\ProvidesFile{psdextra.def}
-%<!none&!packageEnd>  [2023-10-27 v7.01d %
+%<!none&!packageEnd>  [2023-11-11 v7.01e %
 %<package>  Hypertext links for LaTeX]
 %<nohyperref>  Dummy hyperref (SR)]
 %<driver>  Hyperref documentation driver file]
@@ -594,7 +594,6 @@
 % change 2021-08-14: require expl3
 %    \begin{macrocode}
 \ifx\ExplSyntaxOn\undefined \RequirePackage{expl3}\fi
-\RequirePackage{ltxcmds}[2010/11/12]
 \RequirePackage{iftex}[2019/10/24]
 \RequirePackage{pdftexcmds}[2018/09/10]
 %    \end{macrocode}
@@ -618,7 +617,7 @@
   \GenericWarning{%
     (hyperref)\@spaces\@spaces\@spaces\@spaces
   }{%
-    Package hyperref Message: #1\ltx@gobble
+    Package hyperref Message: #1\@gobble
   }%
 }
 %    \end{macrocode}
@@ -634,13 +633,13 @@
 %    \begin{macrocode}
 \def\Hy@VersionCheck#1{%
   \begingroup
-    \ltx@IfUndefined{ver@hyperref.sty}{%
+    \@ifundefined{ver@hyperref.sty}{%
       \Hy@Error{%
         This should not happen!\MessageBreak
         Missing hyperref version%
       }\@ehd
     }{%
-      \ltx@IfUndefined{ver@#1}{%
+      \@ifundefined{ver@#1}{%
         \Hy@Error{%
           This should not happen!\MessageBreak
           Missing version of `#1'%
@@ -689,31 +688,33 @@
 % \subsection{Checks with regular expressions}
 %
 %    \begin{macrocode}
-\ltx@IfUndefined{pdfmatch}{%
+\edef\Hy@leftbracechar{\string{}
+\edef\Hy@rightbracechar{\string}}
+\@ifundefined{pdfmatch}{%
   \def\Hy@Match#1#2#3#4#5{}%
 }{%
   \def\Hy@Match#1#2#3{%
     \begingroup
-    \edef\^{\ltx@backslashchar\string^}%
-    \edef\.{\ltx@backslashchar.}%
-    \edef\[{\ltx@backslashchar[}% ]]
-    \edef\${\ltx@backslashchar$}%
-    \edef\({\ltx@backslashchar(}%
-    \edef\){\ltx@backslashchar)}%
-    \edef\|{\ltx@backslashchar|}%
-    \edef\*{\ltx@backslashchar*}%
-    \edef\+{\ltx@backslashchar+}%
-    \edef\?{\ltx@backslashchar?}%
-    \edef\{{\ltx@backslashchar\ltx@leftbracechar}%
-    \edef\}{\ltx@rightbracechar}%
-    \edef\\{\ltx@backslashchar\ltx@backslashchar}%
-    \let\ \ltx@space
+    \edef\^{\@backslashchar\string^}%
+    \edef\.{\@backslashchar.}%
+    \edef\[{\@backslashchar[}% ]]
+    \edef\${\@backslashchar$}%
+    \edef\({\@backslashchar(}%
+    \edef\){\@backslashchar)}%
+    \edef\|{\@backslashchar|}%
+    \edef\*{\@backslashchar*}%
+    \edef\+{\@backslashchar+}%
+    \edef\?{\@backslashchar?}%
+    \edef\{{\@backslashchar\Hy@leftbracechar}%
+    \edef\}{\Hy@rightbracechar}%
+    \edef\\{\@backslashchar\@backslashchar}%
+    \let\ \Hy@space
     \ifcase\pdfmatch#2{#3}{#1} %
       \endgroup
-      \expandafter\ltx@secondoftwo
+      \expandafter\@secondoftwo
     \or
       \endgroup
-      \expandafter\ltx@firstoftwo
+      \expandafter\@firstoftwo
     \else
       \Hy@Warning{%
         Internal error: Wrong pattern!\MessageBreak
@@ -721,7 +722,7 @@
         Pattern check ignored%
       }%
       \endgroup
-      \expandafter\ltx@firstoftwo
+      \expandafter\@firstoftwo
     \fi
   }%
 }
@@ -755,26 +756,31 @@
 %    `kvoptions' has to perform its option cleanup.
 %    Therefore we use a hook.
 %    \begin{macrocode}
+\ExplSyntaxOn
+\let\Hy@LocalAppendToMacro\tl_put_right:Nn
+\let\Hy@GlobalAppendToMacro\tl_gput_right:Nn
+\let\Hy@ifempty\tl_if_empty:nTF
+\ExplSyntaxOff
 \def\Hy@AtBeginDocument{%
-  \ltx@LocalAppendToMacro\Hy@AtBeginDocumentHook
+  \Hy@LocalAppendToMacro\Hy@AtBeginDocumentHook
 }
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\Hy@AtEndOfPackage}
 %    \begin{macrocode}
 \def\Hy@AtEndOfPackage{%
-  \ltx@LocalAppendToMacro\Hy@AtEndOfPackageHook
+  \Hy@LocalAppendToMacro\Hy@AtEndOfPackageHook
 }
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\Hy@AtBeginDocumentHook}
 %    \begin{macrocode}
-\let\Hy@AtBeginDocumentHook\ltx@empty
+\let\Hy@AtBeginDocumentHook\@empty
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\Hy@AtEndOfPackageHook}
 %    \begin{macrocode}
-\let\Hy@AtEndOfPackageHook\ltx@empty
+\let\Hy@AtEndOfPackageHook\@empty
 %    \end{macrocode}
 %    \end{macro}
 %    Install the hook, before package `kvoptions' is loaded.
@@ -912,18 +918,21 @@
 %
 %    \begin{macrocode}
 \newdimen\@linkdim
-\let\Hy@driver\ltx@empty
+\let\Hy@driver\@empty
 \let\MaybeStopEarly\relax
 \newcount\Hy@linkcounter
 \newcount\Hy@pagecounter
 \Hy@linkcounter0
 \Hy@pagecounter0
+\def\Hy@space{ }
 %    \end{macrocode}
 %
 % \subsection{Macros for recursions}
 %
 %    \begin{macrocode}
 \let\Hy@ReturnEnd\@empty
+\long\def\Hy@ReturnAfterFi#1\fi{\fi#1}
+\long\def\Hy@ReturnAfterElseFi#1\else#2\fi{\fi#1}
 \long\def\Hy@ReturnAfterFiFiEnd#1\fi#2\Hy@ReturnEnd{\fi\fi#1}
 \long\def\Hy@ReturnAfterElseFiFiEnd#1\else#2\Hy@ReturnEnd{\fi\fi#1}
 %    \end{macrocode}
@@ -1189,7 +1198,7 @@
     \let\P\textparagraph
     \let\ldots\textellipsis
     \let\dots\textellipsis
-    \ltx@IfUndefined{textEncodingNoboundary}%
+    \@ifundefined{textEncodingNoboundary}%
       {}{\let\noboundary\textEncodingNoboundary}%
 %    \end{macrocode}
 %
@@ -1336,7 +1345,7 @@
 %    \begin{macrocode}
     \let\foreignlanguage\@secondoftwo
     \let\textlatin\@firstofone
-    \ltx@IfUndefined{language@group}{}{%
+    \@ifundefined{language@group}{}{%
       \let\bbl@info\@gobble
       \csname HyPsd@babel@\language@group\endcsname
     }%
@@ -1464,7 +1473,7 @@
 %
 % \paragraph{Package xspace.}
 %    \begin{macrocode}
-    \ltx@IfUndefined{@xspace}{%
+    \@ifundefined{@xspace}{%
       \let\xspace\HyPsd@ITALCORR
     }{%
       \let\xspace\HyPsd@XSPACE
@@ -1767,7 +1776,7 @@
 %    the string gets an additional \cs{HyPsd@empty}.
 %    \begin{macrocode}
       \expandafter\HyPsd@Subst\expandafter{\/}\HyPsd@empty#1%
-      \ltx@IfUndefined{@xspace}{%
+      \@ifundefined{@xspace}{%
       }{%
         \let\HyPsd@xspace\relax
         \expandafter\HyPsd@Subst\expandafter
@@ -1859,7 +1868,7 @@
 %
 %    \begin{macrocode}
       \ifx\HyPsd@pdfencoding\HyPsd@pdfencoding@auto
-        \ltx@IfUndefined{StringEncodingConvertTest}{%
+        \@ifundefined{StringEncodingConvertTest}{%
         }{%
           \EdefUnescapeString\HyPsd@temp#1%
           \iftutex
@@ -1926,9 +1935,9 @@
   }%
   \Hy@AtEndOfPackage{%
     \pdfstringdefDisableCommands{%
-      \ltx@IfUndefined{oldb}{}{\let\b\oldb}%
-      \ltx@IfUndefined{oldc}{}{\let\c\oldc}%
-      \ltx@IfUndefined{oldd}{}{\let\d\oldd}%
+      \@ifundefined{oldb}{}{\let\b\oldb}%
+      \@ifundefined{oldc}{}{\let\c\oldc}%
+      \@ifundefined{oldd}{}{\let\d\oldd}%
     }%
   }%
 }{%
@@ -2048,9 +2057,12 @@
 %    \end{macro}
 %    \begin{macro}{\HyPsd@LoadExtra}
 %    \begin{macrocode}
+\def\Hy@iffileloaded#1{%
+  \@ifundefined{ver@#1}\@secondoftwo\@firstoftwo
+}
 \def\HyPsd@LoadExtra{%
   \ifHy@psdextra
-    \ltx@iffileloaded{puenc.def}{%
+    \Hy@iffileloaded{puenc.def}{%
       \Hy@SaveCatcodeSettings{psdextra}%
       \input{psdextra.def}%
       \Hy@RestoreCatcodeSettings{psdextra}%
@@ -2137,7 +2149,7 @@
 %    \begin{macro}{\HyPsd@DisableCommands}
 %    \begin{macrocode}
 \long\def\HyPsd@DisableCommands#1{%
-    \ltx@GlobalAppendToMacro\pdfstringdefPreHook{#1}%
+    \Hy@GlobalAppendToMacro\pdfstringdefPreHook{#1}%
   \endgroup
 }
 %    \end{macrocode}
@@ -2234,7 +2246,7 @@
 %    \begin{macro}{\HyPsd@CJKhook}
 %    \begin{macrocode}
 \def\HyPsd@CJKhook{%
-  \ltx@ifpackageloaded{CJK}{%
+  \@ifpackageloaded{CJK}{%
     \let\CJK@kern\relax
     \let\CJKkern\relax
     \let\CJK@CJK\relax
@@ -2776,7 +2788,7 @@
 % \subsubsection{Fix for AMS classes}
 %
 %    \begin{macrocode}
-\ltx@IfUndefined{tocsection}{%
+\@ifundefined{tocsection}{%
   \let\HyPsd@AMSclassfix\relax
 }{%
   \def\HyPsd@AMSclassfix{%
@@ -2954,8 +2966,8 @@
 %    \begin{macro}{\HyPsd@@autorefname}
 %    \begin{macrocode}
 \def\HyPsd@@autorefname#1.#2\@nil{%
-  \ltx@IfUndefined{#1autorefname}{%
-    \ltx@IfUndefined{#1name}{%
+  \@ifundefined{#1autorefname}{%
+    \@ifundefined{#1name}{%
     }{%
       \csname#1name\endcsname\space
     }%
@@ -3111,7 +3123,7 @@
 %    \begin{macrocode}
 \def\HyPsd@Warning#1{%
   \begingroup
-    \let\space\ltx@space
+    \let\space\Hy@space
     \Hy@Warning{#1}%
   \endgroup
 }
@@ -3196,7 +3208,7 @@
 %
 %    Because the string is already expanded, the \cs{if} commands
 %    should disappeared. So we can move some parts out
-%    of the argument of \cs{ltx@ReturnAfterFi}.
+%    of the argument of \cs{Hy@ReturnAfterFi}.
 %    \begin{macrocode}
 \def\HyPsd@@RemoveBracesFi#1#2\HyPsd@End#3\fi{%
   \fi
@@ -3256,7 +3268,7 @@
 %    comparison with \cs{ifcat}, see
 %    \url{http://tracker.luatex.org/view.php?id=773}.
 %    \begin{macrocode}
-\ltx@IfUndefined{directlua}{%
+\@ifundefined{directlua}{%
 }{%
   \expandafter\ifx\csname\endcsname\relax\fi
 }
@@ -3287,7 +3299,7 @@
 %    \begin{macrocode}
 \begingroup
   \catcode`\Q=\active
-  \let Q\ltx@empty
+  \let Q\@empty
   \gdef\HyPsd@CheckCatcodes#1#2\HyPsd@End{%
     \global\let\HyPsd@Rest\relax
     \ifcat\relax\noexpand#1\relax
@@ -3509,7 +3521,7 @@
   }%
   \ifx\\#2\\%
   \else
-    \ltx@ReturnAfterFi{%
+    \Hy@ReturnAfterFi{%
       \HyPsd@GlyphProcessWarning#2\@empty
     }%
   \fi
@@ -3601,12 +3613,12 @@
   \lccode`\|=`\\%
   \lccode`\(=`\{%
   \lccode`\)=`\}%
-  \lccode`0=\ltx@zero
-  \lccode`1=\ltx@zero
-  \lccode`3=\ltx@zero
-  \lccode`4=\ltx@zero
-  \lccode`5=\ltx@zero
-  \lccode`7=\ltx@zero
+  \lccode`0=\z@
+  \lccode`1=\z@
+  \lccode`3=\z@
+  \lccode`4=\z@
+  \lccode`5=\z@
+  \lccode`7=\z@
 \lowercase{\endgroup
   \def\HyPsd@EscapeTeX#1{%
     \HyPsd@Subst!{|045}#1%
@@ -3684,7 +3696,7 @@
   |gdef|HyPsd@DoConvert#1{%
     |ifx#1|@empty
     |else
-      |ltx@ReturnAfterFi{%
+      |Hy@ReturnAfterFi{%
         |ifx#1\%%
           \%%
           |expandafter|HyPsd@DoEscape
@@ -3703,7 +3715,7 @@
     |ifx#19%
       |expandafter|HyPsd@GetTwoBytes
     |else
-      |ltx@ReturnAfterFi{%
+      |Hy@ReturnAfterFi{%
         |ifx#18%
           00%
           |expandafter|HyPsd@GetTwoBytes
@@ -4086,9 +4098,9 @@
 %    \begin{macrocode}
 \def\HyPsd@DieFaceLarge#1!{%
   \ifnum#1>6 %
-    \expandafter\ltx@firstoftwo
+    \expandafter\@firstoftwo
   \else
-    \expandafter\ltx@secondoftwo
+    \expandafter\@secondoftwo
   \fi
   {%
     \9046\205%
@@ -4159,7 +4171,7 @@
 %    \begin{macro}{\HyPsd@@ding}
 %    \begin{macrocode}
 \def\HyPsd@@ding#1!{%
-  \ltx@ifundefined{HyPsd@ding@#1}{%
+  \@ifundefined{HyPsd@ding@#1}{%
     \ifnum#1<127 %
       \9047%
       \HyPsd@DecimalToOctalSecond{\IntCalcSub#1!32!}%
@@ -4220,7 +4232,7 @@
 %    Added fix for version 2.1. Here \cmd{\sub@label} is defined.
 %    \begin{macrocode}
 \@ifpackageloaded{subfigure}{%
-  \ltx@IfUndefined{sub@label}{%
+  \@ifundefined{sub@label}{%
     \Hy@hypertexnamesfalse
   }{%
     \renewcommand*{\sub@label}[1]{%
@@ -4440,8 +4452,8 @@
 %    \begin{macro}{\IfHyperBooleanExists}
 %    \begin{macrocode}
 \def\IfHyperBooleanExists#1{%
-  \ltx@ifundefined{Hy@#1false}\ltx@secondoftwo{%
-    \ltx@ifundefined{KV@Hyp@#1@default}\ltx@secondoftwo\ltx@firstoftwo
+  \@ifundefined{Hy@#1false}\@secondoftwo{%
+    \@ifundefined{KV@Hyp@#1@default}\@secondoftwo\@firstoftwo
   }%
 }
 %    \end{macrocode}
@@ -4455,11 +4467,11 @@
 \def\IfHyperBoolean#1{%
   \IfHyperBooleanExists{#1}{%
     \csname ifHy@#1\endcsname
-      \expandafter\ltx@firstoftwo
+      \expandafter\@firstoftwo
     \else
-      \expandafter\ltx@secondoftwo
+      \expandafter\@secondoftwo
     \fi
-  }\ltx@secondoftwo
+  }\@secondoftwo
 }
 %    \end{macrocode}
 %    \end{macro}
@@ -4505,7 +4517,7 @@
 %    \begin{macro}{\Hy@DisableOption}
 %    \begin{macrocode}
 \def\Hy@DisableOption#1{%
-  \ltx@ifundefined{KV@Hyp@#1@default}{%
+  \@ifundefined{KV@Hyp@#1@default}{%
     \define@key{Hyp}{#1}%
   }{%
     \define@key{Hyp}{#1}[]%
@@ -4914,7 +4926,7 @@
 %
 %    \begin{macrocode}
 \newif\ifHy@DviMode
-\let\Hy@DviErrMsg\ltx@empty
+\let\Hy@DviErrMsg\@empty
 \ifpdf
   \def\Hy@DviErrMsg{pdfTeX or LuaTeX is running in PDF mode}%
 \else
@@ -4934,13 +4946,13 @@
 \fi
 \def\HyOpt@CheckDvi#1{%
   \ifHy@DviMode
-    \expandafter\ltx@firstofone
+    \expandafter\@firstofone
   \else
     \Hy@Error{%
       Wrong DVI mode driver option `#1',\MessageBreak
       because \Hy@DviErrMsg
     }\@ehc
-    \expandafter\ltx@gobble
+    \expandafter\@gobble
   \fi
 }
 %    \end{macrocode}
@@ -5134,7 +5146,7 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\let\HyOpt@DriverFallback\ltx@empty
+\let\HyOpt@DriverFallback\@empty
 \define@key{Hyp}{driverfallback}{%
   \ifHy@DviMode
     \def\HyOpt@DriverFallback{#1}%
@@ -5146,14 +5158,14 @@
         Invalid driver `#1' for option\MessageBreak
         `driverfallback'%
       }%
-      \let\HyOpt@DriverFallback\ltx@empty
+      \let\HyOpt@DriverFallback\@empty
     }%
   \fi
 }
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-\let\HyOpt@CustomDriver\ltx@empty
+\let\HyOpt@CustomDriver\@empty
 \define@key{Hyp}{customdriver}{%
   \IfFileExists{#1.def}{%
     \def\HyOpt@CustomDriver{#1}%
@@ -5822,7 +5834,7 @@
   \def\Hy@colorlink##1{\begingroup}%
   \def\Hy@endcolorlink{\endgroup}%
   \def\@pdfborder{0 0 0}%
-  \let\@pdfborderstyle\ltx@empty
+  \let\@pdfborderstyle\@empty
 }
 \define@key{Hyp}{ocgcolorlinks}[true]{%
   \Hy@boolkey{ocgcolorlinks}{#1}%
@@ -6024,7 +6036,7 @@
       of option `pdfpageduration'\MessageBreak
       is replaced by an empty value%
     }%
-    \let\@pdfpageduration\ltx@empty
+    \let\@pdfpageduration\@empty
   }%
 }
 %    \end{macrocode}
@@ -6421,7 +6433,7 @@
     \x
   \fi
 }
-\global\let\HyInfo@AddonList\ltx@empty
+\global\let\HyInfo@AddonList\@empty
 %    \end{macrocode}
 %    \begin{macrocode}
 \define@key{Hyp}{pdfview}{\calculate@pdfview#1 \\}
@@ -6440,14 +6452,14 @@
   }%
 \define@key{Hyp}{pdfstartpage}{%
   \ifx\\#1\\%
-    \let\@pdfstartpage\ltx@empty
+    \let\@pdfstartpage\@empty
   \else
     \edef\@pdfstartpage{\Hy@number{#1}}%
   \fi
 }%
 \define@key{Hyp}{pdfstartview}{%
   \ifx\\#1\\%
-    \let\@pdfstartview\ltx@empty
+    \let\@pdfstartview\@empty
   \else
     \def\@pdfstartview{/#1}%
   \fi
@@ -6549,7 +6561,7 @@
   \fi
   \ifx\@pdflang\relax
   \else
-    \ifx\@pdflang\ltx@empty
+    \ifx\@pdflang\@empty
     \else
 %    \end{macrocode}
 %    Test according to ABNF of RFC 3066.
@@ -6612,7 +6624,7 @@
                 }%
               }{}%
               \Hy@Match\Hy@temp{icase}{%
-                (-[a-wyz0-9]-).*\ltx@backslashchar1%
+                (-[a-wyz0-9]-).*\@backslashchar1%
               }{%
                 \Hy@Warning{%
                   Invalid language identifier `#1'\MessageBreak
@@ -6683,20 +6695,20 @@
 \def\@runbordercolor{0 .7 .7}
 \def\@citebordercolor{0 1 0}
 \def\@pdfhighlight{/I}
-\let\@pdftitle\ltx@empty
-\let\@pdfauthor\ltx@empty
+\let\@pdftitle\@empty
+\let\@pdfauthor\@empty
 \let\@pdfproducer\relax
 \def\@pdfcreator{LaTeX with hyperref}
-\let\@pdfcreationdate\ltx@empty
-\let\@pdfmoddate\ltx@empty
-\let\@pdfsubject\ltx@empty
-\let\@pdfkeywords\ltx@empty
-\let\@pdftrapped\ltx@empty
-\let\@pdfpagescrop\ltx@empty
+\let\@pdfcreationdate\@empty
+\let\@pdfmoddate\@empty
+\let\@pdfsubject\@empty
+\let\@pdfkeywords\@empty
+\let\@pdftrapped\@empty
+\let\@pdfpagescrop\@empty
 \def\@pdfstartview{/Fit}
 \def\@pdfremotestartview{/Fit}
 \def\@pdfstartpage{1}
-\let\@pdfprintpagerange\ltx@empty
+\let\@pdfprintpagerange\@empty
 \let\@pdflang\relax
 \let\PDF@SetupDoc\@empty
 \let\PDF@FinishDoc\@empty
@@ -6759,21 +6771,21 @@
   \@ifpackageloaded{tex4ht}{%
     \PassOptionsToPackage{tex4ht}{hyperref}%
   }{%
-    \ltx@IfUndefined{HCode}{%
+    \@ifundefined{HCode}{%
     }{%
       \begingroup
         \def\Hy@pkg{tex4ht}%
         \def\Hy@temp@A#1\RequirePackage[#2]#3#4\Hy@NIL{%
           \def\Hy@param{#2#3}%
-          \ifx\Hy@param\ltx@empty
-            \expandafter\ltx@gobble
+          \ifx\Hy@param\@empty
+            \expandafter\@gobble
           \else
             \def\Hy@param{#3}%
             \ifx\Hy@param\Hy@pkg
               \PassOptionsToPackage{#2}{tex4ht}%
               \expandafter\expandafter\expandafter\@gobble
             \else
-              \expandafter\expandafter\expandafter\ltx@firstofone
+              \expandafter\expandafter\expandafter\@firstofone
             \fi
           \fi
           {\Hy@temp@A#4\Hy@NIL}%
@@ -6798,12 +6810,12 @@
 %
 %    \begin{macrocode}
 \def\Hy@xspace@end{}
-\ltx@IfUndefined{xspaceaddexceptions}{%
+\@ifundefined{xspaceaddexceptions}{%
   \Hy@AtBeginDocument{%
-    \ltx@IfUndefined{xspaceaddexceptions}{%
+    \@ifundefined{xspaceaddexceptions}{%
     }{%
       \def\Hy@xspace@end{%
-        \ltx@gobble{end for xspace}%
+        \@gobble{end for xspace}%
       }%
       \xspaceaddexceptions{%
         \Hy@xspace@end,\hyper@linkend,\hyper@anchorend
@@ -6812,7 +6824,7 @@
   }%
 }{%
   \def\Hy@xspace@end{%
-    \ltx@gobble{end for xspace}%
+    \@gobble{end for xspace}%
   }%
   \xspaceaddexceptions{\Hy@xspace@end,\hyper@linkend,\hyper@anchorend}%
 }
@@ -7100,8 +7112,8 @@
 %    If the driver is not given, find the right driver or
 %    use the default driver.
 %    \begin{macrocode}
-  \let\HyOpt@DriverType\ltx@empty
-  \ifx\HyOpt@CustomDriver\ltx@empty
+  \let\HyOpt@DriverType\@empty
+  \ifx\HyOpt@CustomDriver\@empty
     \ifx\Hy@driver\@empty
       \def\HyOpt@DriverType{ (autodetected)}%
       \providecommand*{\Hy@defaultdriver}{hdvips}%
@@ -7135,7 +7147,7 @@
                 \ifnum\ifvtex\OpMode\else\m@ne\fi=\tw@
                   \def\Hy@driver{hvtex}%
                 \else
-                  \ifx\HyOpt@DriverFallback\ltx@empty
+                  \ifx\HyOpt@DriverFallback\@empty
                     \let\Hy@driver\Hy@defaultdriver
                     \def\HyOpt@DriverType{ (default)}%
                   \else
@@ -7145,7 +7157,7 @@
                         \noexpand\kvsetkeys{Hyp}{\the\toks@}%
                       }%
                     \x
-                    \ifx\Hy@driver\ltx@empty
+                    \ifx\Hy@driver\@empty
                       \let\Hy@driver\Hy@defaultdriver
                       \def\HyOpt@DriverType{ (default)}%
                     \else
@@ -7246,7 +7258,7 @@
     \def\@pdfpagemode{UseOutlines}%
   \fi
 \else
-  \let\@bookmarkopenstatus\ltx@gobble
+  \let\@bookmarkopenstatus\@gobble
   \Hy@Info{Bookmarks OFF}%
   \Hy@AtEndOfPackage{%
     \global\let\ReadBookmarks\relax
@@ -7262,7 +7274,7 @@
 %    Add wrapper for setting standard catcodes (babel's shorthands).
 %    \begin{macrocode}
 \def\Hy@CatcodeWrapper#1{%
-  \let\Hy@EndWrap\ltx@empty
+  \let\Hy@EndWrap\@empty
   \def\TMP@EnsureCode##1##2{%
     \edef\Hy@EndWrap{%
       \Hy@EndWrap
@@ -7447,11 +7459,11 @@
   \gdef\hyper@n@rmalise#1#2{^^A
     \def\Hy@tempa{#2}^^A
     \ifx\Hy@tempa\Hy@ActiveCarriageReturn
-      \ltx@ReturnAfterElseFi{^^A
+      \Hy@ReturnAfterElseFi{^^A
         \hyper@@normalise{#1}^^A
       }^^A
     \else
-      \ltx@ReturnAfterFi{^^A
+      \Hy@ReturnAfterFi{^^A
         \hyper@@normalise{#1}{#2}^^A
       }^^A
     \fi
@@ -7467,7 +7479,7 @@
     #1^^A
     \ifx\limits#2\limits
     \else
-      \ltx@ReturnAfterFi{^^A
+      \Hy@ReturnAfterFi{^^A
         \Hy@RemovePercentCr #2\@nil
       }^^A
     \fi
@@ -7610,7 +7622,7 @@
 %    \begin{macrocode}
 \newif\ifHy@href@ismap
 \define@key{href}{ismap}[true]{%
-  \ltx@IfUndefined{Hy@href@ismap#1}{%
+  \@ifundefined{Hy@href@ismap#1}{%
     \Hy@Error{%
       Invalid value (#1) for key `ismap'.\MessageBreak
       Permitted values are `true' or `false'.\MessageBreak
@@ -7886,18 +7898,18 @@
 % #3: destination name
 % #4: text
 \def\hyper@link@[#1]#2#3#4{%
-  \ltx@ifempty{#4}{% link text
+  \Hy@ifempty{#4}{% link text
     \Hy@Warning{Suppressing empty link}%
   }{%
     \begingroup
       \protected@edef\Hy@tempa{#2}%
       \edef\Hy@tempb{#3}%
-      \ifx\Hy@tempa\ltx@empty
-        \ifx\Hy@tempb\ltx@empty
+      \ifx\Hy@tempa\@empty
+        \ifx\Hy@tempb\@empty
           \Hy@Warning{Suppressing link with empty target}%
           \toks@{%
             \endgroup
-            \ltx@secondoftwo
+            \@secondoftwo
           }%
         \else
           \toks@{%
@@ -8059,9 +8071,9 @@
     \expandafter\def\expandafter\z\expandafter##\expandafter1\y##2\@nil{%
       \endgroup
       \ifx\relax##2\relax
-        \expandafter\ltx@secondoftwo
+        \expandafter\@secondoftwo
       \else
-        \expandafter\ltx@firstoftwo
+        \expandafter\@firstoftwo
       \fi
     }%
   \expandafter\expandafter\expandafter\z\expandafter\x\y\@nil
@@ -8136,7 +8148,7 @@
   \fi
   \let\anchor@spot\@empty
 }
-\let\anchor@spot\ltx@empty
+\let\anchor@spot\@empty
 %    \end{macrocode}
 %
 % \section{Option `destlabel'}
@@ -8167,7 +8179,7 @@
 %    \begin{macro}{\Hy@DestRename}
 %    \begin{macrocode}
   \newcommand*{\Hy@DestRename}[2]{%
-    \ltx@IfUndefined{HyDL!#1}{%
+    \@ifundefined{HyDL!#1}{%
       \begingroup
         \Hy@safe@activestrue
         \edef\dest@name{#1}%
@@ -8176,7 +8188,7 @@
         \Hy@IsNotEmpty{dest@name}{%
           \Hy@IsNotEmpty{label@name}{%
             \global\expandafter
-            \let\csname HyDL!#1\endcsname\ltx@empty
+            \let\csname HyDL!#1\endcsname\@empty
             \if@filesw
               \protected@write\@auxout{}{%
                 \string\hyper@newdestlabel
@@ -8206,18 +8218,18 @@
 %    \begin{macro}{\Hy@IsNotEmpty}
 %    \begin{macrocode}
   \def\Hy@IsNotEmpty#1{%
-    \ltx@IfUndefined{#1}\ltx@gobble{%
-      \expandafter\ifx\csname#1\endcsname\ltx@empty
-        \expandafter\ltx@gobble
+    \@ifundefined{#1}\@gobble{%
+      \expandafter\ifx\csname#1\endcsname\@empty
+        \expandafter\@gobble
       \else
-        \expandafter\ltx@firstofone
+        \expandafter\@firstofone
       \fi
     }%
   }%
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macrocode}
-  \ltx@GlobalAppendToMacro\label@hook{%
+  \Hy@GlobalAppendToMacro\label@hook{%
     \HyperDestRename\@currentHref\label@name
   }%
 %    \end{macrocode}
@@ -8225,7 +8237,7 @@
 %    \begin{macro}{\HyperDestLabelReplace}
 %    \begin{macrocode}
   \def\HyperDestLabelReplace#1{%
-    \ltx@ifundefined{HyDL@#1}{%
+    \@ifundefined{HyDL@#1}{%
       #1%
     }{%
       \csname HyDL@#1\endcsname
@@ -8244,17 +8256,17 @@
 %    \end{macrocode}
 %    \begin{macro}{\hyper@newdestlabel}
 %    \begin{macrocode}
-  \let\hyper@newdestlabel\ltx@gobbletwo
+  \let\hyper@newdestlabel\@gobbletwo
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\HyperDestLabelReplace}
 %    \begin{macrocode}
-  \let\HyperDestLabelReplace\ltx@firstofone
+  \let\HyperDestLabelReplace\@firstofone
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\HyperDestRename}
 %    \begin{macrocode}
-  \let\HyperDestRename\ltx@gobbletwo
+  \let\HyperDestRename\@gobbletwo
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macrocode}
@@ -8590,7 +8602,7 @@
   \fi
   \HyField@PrintFlags{Submit}{submit button field}%
   \bitsetIsEmpty{HyField@Submit}{%
-    \let\Fld@submitflags\ltx@empty
+    \let\Fld@submitflags\@empty
   }{%
     \edef\Fld@submitflags{/Flags \bitsetGetDec{HyField@Submit}}%
   }%
@@ -8615,7 +8627,7 @@
   \HyField@UseFlag{F}{LockedContents}%
   \HyField@PrintFlags{F}{#1}%
   \bitsetIsEmpty{HyField@F}{%
-    \let\Fld@annotflags\ltx@empty
+    \let\Fld@annotflags\@empty
   }{%
     \edef\Fld@annotflags{/F \bitsetGetDec{HyField@F}}%
   }%
@@ -8636,7 +8648,7 @@
   \HyField@SetFlag{Ff}{Pushbutton}%
   \HyField@PrintFlags{Ff}{push button field}%
   \bitsetIsEmpty{HyField@Ff}{%
-    \let\Fld@flags\ltx@empty
+    \let\Fld@flags\@empty
   }{%
     \edef\Fld@flags{/Ff \bitsetGetDec{HyField@Ff}}%
   }%
@@ -8656,7 +8668,7 @@
   \HyField@UseFlag{Ff}{NoExport}%
   \HyField@PrintFlags{Ff}{check box field}%
   \bitsetIsEmpty{HyField@Ff}{%
-    \let\Fld@flags\ltx@empty
+    \let\Fld@flags\@empty
   }{%
     \edef\Fld@flags{/Ff \bitsetGetDec{HyField@Ff}}%
   }%
@@ -8679,7 +8691,7 @@
   \HyField@UseFlag{Ff}{RadiosInUnison}%
   \HyField@PrintFlags{Ff}{radio button field}%
   \bitsetIsEmpty{HyField@Ff}{%
-    \let\Fld@flags\ltx@empty
+    \let\Fld@flags\@empty
   }{%
     \edef\Fld@flags{/Ff \bitsetGetDec{HyField@Ff}}%
   }%
@@ -8718,7 +8730,7 @@
   \HyField@UseFlag{Ff}{RichText}%
   \HyField@PrintFlags{Ff}{text field}%
   \bitsetIsEmpty{HyField@Ff}{%
-    \let\Fld@flags\ltx@empty
+    \let\Fld@flags\@empty
   }{%
     \edef\Fld@flags{/Ff \bitsetGetDec{HyField@Ff}}%
   }%
@@ -8750,7 +8762,7 @@
   \HyField@UseFlag{Ff}{CommitOnSelChange}%
   \HyField@PrintFlags{Ff}{choice field}%
   \bitsetIsEmpty{HyField@Ff}{%
-    \let\Fld@flags\ltx@empty
+    \let\Fld@flags\@empty
   }{%
     \edef\Fld@flags{/Ff \bitsetGetDec{HyField@Ff}}%
   }%
@@ -8768,8 +8780,8 @@
 %    \begin{macrocode}
 \def\HyField@PDFChoices#1{%
   \begingroup
-    \global\let\Fld@choices\ltx@empty
-    \let\HyTmp@optlist\ltx@empty
+    \global\let\Fld@choices\@empty
+    \let\HyTmp@optlist\@empty
     \let\HyTmp@optitem\relax
     \count@=0 %
     \kv@parse{#1}{%
@@ -9111,7 +9123,7 @@
   \Fld@DingDef\Fld@radiosymbol{#1}%
 }
 \def\Fld@DingDef#1#2{%
-  \let\Fld@temp\ltx@empty
+  \let\Fld@temp\@empty
   \Fld@@DingDef#2\ding{}\@nil
   \let#1\Fld@temp
 }
@@ -9155,17 +9167,17 @@
 }
 %    \end{macrocode}
 %    \begin{macrocode}
-\let\Fld@onclick@code\ltx@empty
-\let\Fld@format@code\ltx@empty
-\let\Fld@validate@code\ltx@empty
-\let\Fld@calculate@code\ltx@empty
-\let\Fld@keystroke@code\ltx@empty
-\let\Fld@onfocus@code\ltx@empty
-\let\Fld@onblur@code\ltx@empty
-\let\Fld@onmousedown@code\ltx@empty
-\let\Fld@onmouseup@code\ltx@empty
-\let\Fld@onenter@code\ltx@empty
-\let\Fld@onexit@code\ltx@empty
+\let\Fld@onclick@code\@empty
+\let\Fld@format@code\@empty
+\let\Fld@validate@code\@empty
+\let\Fld@calculate@code\@empty
+\let\Fld@keystroke@code\@empty
+\let\Fld@onfocus@code\@empty
+\let\Fld@onblur@code\@empty
+\let\Fld@onmousedown@code\@empty
+\let\Fld@onmouseup@code\@empty
+\let\Fld@onenter@code\@empty
+\let\Fld@onexit@code\@empty
 \def\Hy@temp#1{%
   \expandafter\Hy@@temp\csname Fld@#1@code\endcsname{#1}%
 }
@@ -9192,7 +9204,7 @@
 \Hy@temp{onexit}
 %    \end{macrocode}
 %    \begin{macrocode}
-\let\Fld@calculate@sortkey\ltx@empty
+\let\Fld@calculate@sortkey\@empty
 \define@key{Field}{calculatesortkey}[1]{%
   \def\Fld@calculate@sortkey{#1}%
 }
@@ -9447,10 +9459,10 @@
   \def\hyper@@anchor##1##2{##2\Hy@xspace@end}%
   \global\let\hyper@livelink\hyper@link
   \gdef\hyper@link##1##2##3{##3\Hy@xspace@end}%
-  \let\hyper@anchor\ltx@gobble
-  \let\hyper@anchorstart\ltx@gobble
+  \let\hyper@anchor\@gobble
+  \let\hyper@anchorstart\@gobble
   \def\hyper@anchorend{\Hy@xspace@end}%
-  \let\hyper@linkstart\ltx@gobbletwo
+  \let\hyper@linkstart\@gobbletwo
   \def\hyper@linkend{\Hy@xspace@end}%
   \def\hyper@linkurl##1##2{##1\Hy@xspace@end}%
   \def\hyper@linkfile##1##2##3{##1\Hy@xspace@end}%
@@ -9459,12 +9471,12 @@
 \def\stop@hyper{%
   \def\hyper@link@[##1]##2##3##4{##4\Hy@xspace@end}%
   \let\Hy@backout\@gobble
-  \let\hyper@@anchor\ltx@gobble
+  \let\hyper@@anchor\@gobble
   \def\hyper@link##1##2##3{##3\Hy@xspace@end}%
-  \let\hyper@anchor\ltx@gobble
-  \let\hyper@anchorstart\ltx@gobble
+  \let\hyper@anchor\@gobble
+  \let\hyper@anchorstart\@gobble
   \def\hyper@anchorend{\Hy@xspace@end}%
-  \let\hyper@linkstart\ltx@gobbletwo
+  \let\hyper@linkstart\@gobbletwo
   \def\hyper@linkend{\Hy@xspace@end}%
   \def\hyper@linkurl##1##2{##1\Hy@xspace@end}%
   \def\hyper@linkfile##1##2##3{##1\Hy@xspace@end}%
@@ -9596,7 +9608,7 @@
           \string\gdef\string\HyperFirstAtBeginDocument\string#1{\string#1}%
         }%
       \fi
-      \let\HyperFirstAtBeginDocument\ltx@firstofone
+      \let\HyperFirstAtBeginDocument\@firstofone
 %    \end{macrocode}
 %
 % Now the code to deal with adding the hyperref package to a document
@@ -9688,7 +9700,7 @@
 %
 %    \begin{macrocode}
 \def\Hy@UseMaketitleString#1{%
-  \ltx@IfUndefined{Hy@#1}{}{%
+  \@ifundefined{Hy@#1}{}{%
     \begingroup
       \let\Hy@saved@hook\pdfstringdefPreHook
       \pdfstringdefDisableCommands{%
@@ -9721,12 +9733,12 @@
 %
 %    \begin{macrocode}
 \RequirePackage{atbegshi}[2007/09/09]
-\let\Hy@EveryPageHook\ltx@empty
-\let\Hy@EveryPageBoxHook\ltx@empty
-\let\Hy@FirstPageHook\ltx@empty
+\let\Hy@EveryPageHook\@empty
+\let\Hy@EveryPageBoxHook\@empty
+\let\Hy@FirstPageHook\@empty
 \AtBeginShipout{%
   \Hy@EveryPageHook
-  \ifx\Hy@EveryPageBoxHook\ltx@empty
+  \ifx\Hy@EveryPageBoxHook\@empty
   \else
     \setbox\AtBeginShipoutBox=\vbox{%
       \offinterlineskip
@@ -9735,10 +9747,10 @@
     }%
   \fi
 }
-\ltx@iffileloaded{hpdftex.def}{%
+\Hy@iffileloaded{hpdftex.def}{%
   \AtBeginShipout{%
     \Hy@FirstPageHook
-    \global\let\Hy@FirstPageHook\ltx@empty
+    \global\let\Hy@FirstPageHook\@empty
   }%
 }{%
   \AtBeginShipoutFirst{%
@@ -9747,7 +9759,7 @@
 }
 \g@addto@macro\Hy@FirstPageHook{%
   \PDF@FinishDoc
-  \global\let\PDF@FinishDoc\ltx@empty
+  \global\let\PDF@FinishDoc\@empty
 }
 %    \end{macrocode}
 %
@@ -9783,7 +9795,7 @@
 %    The page labels are collected in \cmd{\HyPL@Labels} and
 %    set at the end of the document.
 %    \begin{macrocode}
-  \let\HyPL@Labels\ltx@empty
+  \let\HyPL@Labels\@empty
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\Hy@abspage}
@@ -9799,7 +9811,7 @@
 %    \begin{macrocode}
   \def\HyPL@LastType{init}%
   \def\HyPL@LastNumber{0}%
-  \let\HyPL@LastPrefix\ltx@empty
+  \let\HyPL@LastPrefix\@empty
 %    \end{macrocode}
 %    Definitions for the PDF names of the \LaTeX{} pendents.
 %    \begin{macrocode}
@@ -9811,18 +9823,18 @@
 %    \end{macrocode}
 %
 %    \begin{macrocode}
-  \let\HyPL@SlidesSetPage\ltx@empty
-  \ltx@ifclassloaded{slides}{%
+  \let\HyPL@SlidesSetPage\@empty
+  \@ifclassloaded{slides}{%
     \def\HyPL@SlidesSetPage{%
-      \advance\c@page\ltx@one
-      \ifnum\value{page}>\ltx@one
+      \advance\c@page\@ne
+      \ifnum\value{page}>\@ne
         \protected@edef\HyPL@SlidesOptionalPage{%
           \Hy@SlidesFormatOptionalPage{\thepage}%
         }%
       \else
-        \let\HyPL@SlidesOptionalPage\ltx@empty
+        \let\HyPL@SlidesOptionalPage\@empty
       \fi
-      \advance\c@page-\ltx@one
+      \advance\c@page-\@ne
       \def\HyPL@page{%
         \csname the\Hy@SlidesPage\endcsname
         \HyPL@SlidesOptionalPage
@@ -9847,7 +9859,7 @@
       \fi
       \let\HyPL@Type\relax
       \ifnum\c@page>0 %
-        \ifx\HyPL@SlidesSetPage\ltx@empty
+        \ifx\HyPL@SlidesSetPage\@empty
           \expandafter\HyPL@CheckThePage\HyPL@page\@nil
         \fi
       \fi
@@ -10046,7 +10058,7 @@
 %    \begin{macrocode}
 %<*pdftex>
 \pdf@ifdraftmode{%
-  \let\Hy@PutCatalog\ltx@gobble
+  \let\Hy@PutCatalog\@gobble
 }{%
   \let\Hy@PutCatalog\pdfcatalog
 }
@@ -10342,7 +10354,7 @@
 \Hy@CounterExists{part}{%
   \providecommand\theHpart{\arabic{part}}%
 }
-\ltx@IfUndefined{thechapter}{%
+\@ifundefined{thechapter}{%
   \providecommand\theHsection    {\arabic{section}}%
   \providecommand\theHfigure     {\arabic{figure}}%
   \providecommand\theHtable      {\arabic{table}}%
@@ -10474,7 +10486,7 @@
   \@ifundefined{theH#1}{%
     \expandafter\def\csname theH#1\endcsname{}%
     \def\Hy@temp{\@elt{#1}}%
-    \ltx@onelevel@sanitize\Hy@temp
+    \@nelevel@sanitize\Hy@temp
     \let\HyOrg@elt\@elt
     \edef\@elt{%
       \noexpand\HyCnt@LookForParentCounter
@@ -10483,7 +10495,7 @@
     \cl@@ckpt
     \let\@elt\HyOrg@elt
     \expandafter
-    \ltx@LocalAppendToMacro\csname theH#1\expandafter\endcsname
+    \Hy@LocalAppendToMacro\csname theH#1\expandafter\endcsname
     \expandafter{%
       \expandafter\@arabic\csname c@#1\endcsname
     }%
@@ -10495,20 +10507,20 @@
 %    \begin{macrocode}
 \def\HyCnt@LookForParentCounter#1#2{%
   \expandafter\let\expandafter\Hy@temp@A\csname cl@#2\endcsname
-  \ltx@IfUndefined{cl@#2}{%
+  \@ifundefined{cl@#2}{%
   }{%
-    \ltx@onelevel@sanitize\Hy@temp@A
+    \@nelevel@sanitize\Hy@temp@A
     \edef\Hy@temp@A{%
       \noexpand\in@{\Hy@temp}{\Hy@temp@A}%
     }\Hy@temp@A
     \ifin@
-      \ltx@IfUndefined{theH#2}{%
-        \expandafter\ltx@LocalAppendToMacro\expandafter#1%
+      \@ifundefined{theH#2}{%
+        \expandafter\Hy@LocalAppendToMacro\expandafter#1%
         \expandafter{%
           \expandafter\@arabic\csname c@#2\endcsname.%
         }%
       }{%
-        \expandafter\ltx@LocalAppendToMacro\expandafter#1%
+        \expandafter\Hy@LocalAppendToMacro\expandafter#1%
         \expandafter{%
           \csname theH#2\endcsname.%
         }%
@@ -10537,7 +10549,7 @@
 \fi
 \def\Hy@appendixstring{appendix}
 \def\Hy@chapapp{\Hy@chapterstring}
-\ltx@IfUndefined{appendix}{%
+\@ifundefined{appendix}{%
 }{%
   \let\HyOrg@appendix\appendix
   \def\Hy@AlphNoErr#1{%
@@ -10552,7 +10564,7 @@
     \fi
   }%
   \def\appendix{%
-    \ltx@IfUndefined{chapter}{%
+    \@ifundefined{chapter}{%
       \gdef\theHsection{\Hy@AlphNoErr{section}}%
     }{%
       \gdef\theHchapter{\Hy@AlphNoErr{chapter}}%
@@ -10847,7 +10859,7 @@
       \let\refstepcounter\new@refstepcounter
     }%
     \def\endequation{%
-      \ifx\Hy@raisedlink\ltx@empty
+      \ifx\Hy@raisedlink\@empty
         \hyper@anchorend
       \else
         \mathclose{\Hy@raisedlink{\hyper@anchorend}}%
@@ -10906,7 +10918,7 @@
 % Then again, we have the \emph{subeqnarray}
 % package. Tanmoy provided some code for this:
 %    \begin{macrocode}
-\ltx@IfUndefined{subeqnarray}{}{%
+\@ifundefined{subeqnarray}{}{%
   \let\H@subeqnarray\subeqnarray
   \let\H@endsubeqnarray\endsubeqnarray
   \def\subeqnarray{%
@@ -11096,9 +11108,9 @@
   \long\def\@mpfootnotetext#1{%
     \H@@mpfootnotetext{%
       \ifHy@nesting
-        \expandafter\ltx@firstoftwo
+        \expandafter\@firstoftwo
       \else
-        \expandafter\ltx@secondoftwo
+        \expandafter\@secondoftwo
       \fi
       {%
         \expandafter\hyper@@anchor\expandafter{%
@@ -11116,9 +11128,9 @@
   \long\def\@footnotetext#1{%
     \H@@footnotetext{%
       \ifHy@nesting
-        \expandafter\ltx@firstoftwo
+        \expandafter\@firstoftwo
       \else
-        \expandafter\ltx@secondoftwo
+        \expandafter\@secondoftwo
       \fi
       {%
         \expandafter\hyper@@anchor\expandafter{%
@@ -11536,7 +11548,7 @@
 %    \begin{macrocode}
 \@ifundefined{hyper@nopatch@bib}
  {%
-   \ltx@IfUndefined{NAT@parse}{%
+   \@ifundefined{NAT@parse}{%
      \providecommand*\@extra@binfo{}%
      \providecommand*\@extra@b@citeb{}%
      \def\bibcite#1#2{%
@@ -11812,12 +11824,12 @@
 \def\@currentHpage{Doc-Start}
 %    \end{macrocode}
 %    \begin{macrocode}
-\ltx@ifclassloaded{slides}{%
+\@ifclassloaded{slides}{%
   \def\Hy@SlidesFormatOptionalPage#1{(#1)}%
   \def\Hy@PageAnchorSlidesPlain{%
-    \advance\c@page\ltx@one
+    \advance\c@page\@ne
     \xdef\@currentHpage{page.\the\c@slide.\the\c@overlay.\the\c@note%
-        \ifnum\c@page=\ltx@one
+        \ifnum\c@page=\@ne
         \else
           .\the\c@page
         \fi}%
@@ -11826,12 +11838,12 @@
         \@currentHpage
       }%
     }%
-    \advance\c@page-\ltx@one
+    \advance\c@page-\@ne
   }%
   \def\Hy@PageAnchorSlide{%
-    \advance\c@page\ltx@one
-    \ifnum\c@page>\ltx@one
-      \ltx@IfUndefined{theHpage}{%
+    \advance\c@page\@ne
+    \ifnum\c@page>\@ne
+      \@ifundefined{theHpage}{%
         \protected@edef\Hy@TheSlideOptionalPage{%
           \Hy@SlidesFormatOptionalPage{\thepage}%
         }%
@@ -11843,16 +11855,16 @@
     \else
       \def\Hy@TheSlideOptionalPage{}%
     \fi
-    \advance\c@page-\ltx@one
+    \advance\c@page-\@ne
     \pdfstringdef\@the@H@page{%
       \csname
         the%
-        \ltx@ifundefined{theH\Hy@SlidesPage}{}{H}%
+        \@ifundefined{theH\Hy@SlidesPage}{}{H}%
         \Hy@SlidesPage
       \endcsname
       \Hy@TheSlideOptionalPage
     }%
-    \ltx@gobblethree
+    \@gobblethree
   }%
   \def\Hy@SlidesPage{slide}%
   \g@addto@macro\slide{%
@@ -12001,7 +12013,7 @@
     \edef\x{\endgroup
       \def\noexpand\Hy@tocdestname{#4}%
     }\x
-    \ifx\Hy@tocdestname\ltx@empty
+    \ifx\Hy@tocdestname\@empty
       \csname l@#1\endcsname{#2}{#3}%
     \else
       \ifcase\Hy@linktoc % none
@@ -12012,7 +12024,7 @@
         }{#3}%
       \or % page
         \def\Hy@temp{#3}%
-        \ifx\Hy@temp\ltx@empty
+        \ifx\Hy@temp\@empty
           \csname l@#1\endcsname{#2}{#3}%
         \else
           \csname l@#1\endcsname{{#2}}{%
@@ -12021,7 +12033,7 @@
         \fi
       \else % all
         \def\Hy@temp{#3}%
-        \ifx\Hy@temp\ltx@empty
+        \ifx\Hy@temp\@empty
           \csname l@#1\endcsname{%
             \Hy@toclinkstart{#2}\Hy@toclinkend
           }{}%
@@ -12304,8 +12316,8 @@
           \ifx\\#3\\%
             \ifx\Hy@temp@A\HyInd@ParenRight
               \HyInd@DefKey{#1}%
-              \ltx@IfUndefined{HyInd@(\HyInd@key)}{%
-                \let\Hy@temp\ltx@empty
+              \@ifundefined{HyInd@(\HyInd@key)}{%
+                \let\Hy@temp\@empty
               }{%
                 \expandafter\let\expandafter\Hy@temp
                 \csname HyInd@(\HyInd@key)\endcsname
@@ -12343,7 +12355,7 @@
         \begingroup
           \let\protect\@unexpandable@protect
           \edef\Hy@temp{#1}%
-          \ltx@onelevel@sanitize\Hy@temp
+          \@nelevel@sanitize\Hy@temp
           \global\let\HyInd@key\Hy@temp
         \endgroup
       }%
@@ -12375,7 +12387,7 @@
   \def\Hy@temp{#3}%
   \ifx\Hy@temp\@empty
   \else
-    \ltx@ReturnAfterFi{%
+    \Hy@ReturnAfterFi{%
       \HyInd@hyperpage#3\@nil
     }%
   \fi
@@ -12417,7 +12429,7 @@
       \hyperlink{page.\the\toks@}{\the\toks@}%
     \fi
   \else
-    \ltx@ReturnAfterFi{%
+    \Hy@ReturnAfterFi{%
       \HyInd@removespaces#2\@nil
     }%
   \fi
@@ -12591,8 +12603,8 @@
   \hyperref[{#1}]{\HyRef@autopagerefname\pageref*{#1}}%
 }
 \def\HyRef@autopagerefname{%
-  \ltx@IfUndefined{pageautorefname}{%
-    \ltx@IfUndefined{pagename}{%
+  \@ifundefined{pageautorefname}{%
+    \@ifundefined{pagename}{%
       \Hy@Warning{No autoref name for `page'}%
     }{%
       \pagename\nobreakspace
@@ -12640,11 +12652,11 @@
   \fi
 }
 \def\HyRef@testreftype#1.#2\\{%
-  \ltx@IfUndefined{#1autorefname}{%
-    \ltx@IfUndefined{#1name}{%
+  \@ifundefined{#1autorefname}{%
+    \@ifundefined{#1name}{%
       \HyRef@StripStar#1\\*\\\@nil{#1}%
-      \ltx@IfUndefined{\HyRef@name autorefname}{%
-        \ltx@IfUndefined{\HyRef@name name}{%
+      \@ifundefined{\HyRef@name autorefname}{%
+        \@ifundefined{\HyRef@name name}{%
           \def\HyRef@currentHtag{}%
           \Hy@Warning{No autoref name for `#1'}%
         }{%
@@ -12770,7 +12782,7 @@
       |ifx|\#2|\%%
       |else
         \\%
-        |ltx@ReturnAfterFi{%
+        |Hy@ReturnAfterFi{%
           |Hy@ExchangeBackslash#2|@nil
         }%
       |fi
@@ -12781,7 +12793,7 @@
     \ifx\\#2\\%
     \else
       \@backslashchar(%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@ExchangeLeftParenthesis#2\@nil
       }%
     \fi
@@ -12791,7 +12803,7 @@
     \ifx\\#2\\%
     \else
       \@backslashchar)%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@ExchangeRightParenthesis#2\@nil
       }%
     \fi
@@ -12840,7 +12852,7 @@
 \fi
 \ifHy@setpdfversion
   \ifnum\Hy@pdf@majorminor@version<105 %
-    \ltx@IfUndefined{pdfobjcompresslevel}{%
+    \@ifundefined{pdfobjcompresslevel}{%
     }{%
       \ifHy@verbose
         \Hy@InfoNoLine{%
@@ -12850,19 +12862,19 @@
           \Hy@pdf@majorversion.\Hy@pdf@minorversion
         }%
       \fi
-      \pdfobjcompresslevel=\ltx@zero
+      \pdfobjcompresslevel=\z@
     }%
   \fi
   \ifnum\Hy@pdfmajorminor@version=\Hy@pdf@majorminor@version\relax
   \else
-    \let\Hy@temp\ltx@empty
+    \let\Hy@temp\@empty
     \def\Hy@temp@A#1#2{%
-      \ifnum#1>\ltx@zero
+      \ifnum#1>\z@
         \edef\Hy@temp{%
           \Hy@temp
           \space\space
           \the#1\space #2%
-          \ifnum#1=\ltx@one\else s\fi
+          \ifnum#1=\@ne\else s\fi
           \MessageBreak
         }%
       \fi
@@ -12871,15 +12883,15 @@
     \Hy@temp@A\pdflastxform{form XObject}%
     \Hy@temp@A\pdflastximage{image XObject}%
     \Hy@temp@A\pdflastannot{annotation}%
-    \ltx@IfUndefined{pdflastlink}{%
+    \@ifundefined{pdflastlink}{%
     }{%
        \Hy@temp@A\pdflastlink{link}%
     }%
-    \ifx\Hy@temp\ltx@empty
+    \ifx\Hy@temp\@empty
       \Hy@pdfmajorversion=\Hy@pdf@majorversion\relax
       \Hy@pdfminorversion=\Hy@pdf@minorversion\relax
     \else
-      \let\Hy@temp@A\ltx@empty
+      \let\Hy@temp@A\@empty
       \ifnum\Hy@pdf@majorminor@version=104 %
         \IfFileExists{pdf14.sty}{%
           \def\Hy@temp@A{%
@@ -12902,7 +12914,7 @@
         \expandafter\string\Hy@pdfminorversion=\Hy@pdf@minorversion
         \string\relax
         \ifnum\Hy@pdf@majorminor@version<105 %
-          \ltx@ifundefined{pdfobjcompresslevel}{%
+          \@ifundefined{pdfobjcompresslevel}{%
           }{%
             \MessageBreak
             \space\space
@@ -13128,7 +13140,7 @@
 }
 \def\hyper@linkstart#1#2{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{\csname @#1bordercolor\endcsname}%
@@ -13138,7 +13150,7 @@
 \def\hyper@linkend{\close@pdflink}
 \def\hyper@link#1#2#3{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{\csname @#1bordercolor\endcsname}%
@@ -13642,7 +13654,7 @@
 %    \begin{macrocode}
 %<*hypertex>
 \providecommand*{\XR@ext}{dvi}
-\let\PDF@FinishDoc\ltx@empty
+\let\PDF@FinishDoc\@empty
 \def\PDF@SetupDoc{%
   \ifx\@baseurl\@empty
   \else
@@ -14629,7 +14641,7 @@
 \providecommand*{\XR@ext}{htm}
 \RequirePackage{vtexhtml}
 \newif\if@Localurl
-\let\PDF@FinishDoc\ltx@empty
+\let\PDF@FinishDoc\@empty
 \def\PDF@SetupDoc{%
   \ifx\@baseurl\@empty
   \else
@@ -14716,7 +14728,7 @@
 \def\@Form[#1]{%
   \Hy@Message{Sorry, TeXpider does not yet support FORMs}%
 }
-\let\@endForm\ltx@empty
+\let\@endForm\@empty
 \def\@Gauge[#1]#2#3#4{% parameters, label, minimum, maximum
   \Hy@Message{Sorry, TeXpider does not yet support FORM gauges}%
 }
@@ -14819,7 +14831,7 @@
   \Hy@VerboseLinkStart{#1}{#2}%
   \Hy@pstringdef\Hy@pstringURI{#2}%
   \expandafter\Hy@colorlink\csname @#1color\endcsname
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{%
@@ -14922,7 +14934,7 @@
 }
 \def\hyper@link#1#2#3{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\CurrentBorderColor\relax
   }{%
     \edef\CurrentBorderColor{\csname @#1bordercolor\endcsname}%
@@ -15501,7 +15513,7 @@
   \endgroup
   \Hy@RestoreLastskip
 }
-\ltx@IfUndefined{hyper@anchorstart}{}{\endinput}
+\@ifundefined{hyper@anchorstart}{}{\endinput}
 \Hy@WrapperDef\hyper@anchorstart#1{%
   \Hy@SaveLastskip
   \Hy@VerboseAnchor{#1}%
@@ -15529,7 +15541,7 @@
     \ifmmode
       \def\Hy@LinkMath{$}%
     \else
-      \let\Hy@LinkMath\ltx@empty
+      \let\Hy@LinkMath\@empty
     \fi
     \Hy@SaveSpaceFactor
     \hbox\bgroup
@@ -15544,7 +15556,7 @@
 }
 \def\hyper@linkend{%
   \literalps@out{\strip@pt@and@otherjunk\baselineskip\space H.L}%
-  \ltx@IfUndefined{@\hyper@currentlinktype bordercolor}{%
+  \@ifundefined{@\hyper@currentlinktype bordercolor}{%
     \let\Hy@tempcolor\relax
   }{%
     \edef\Hy@tempcolor{%
@@ -15643,7 +15655,7 @@
 \def\Hy@undefinedname{UNDEFINED}
 \def\hyper@link#1#2#3{%
   \Hy@VerboseLinkStart{#1}{#2}%
-  \ltx@IfUndefined{@#1bordercolor}{%
+  \@ifundefined{@#1bordercolor}{%
     \let\Hy@tempcolor\relax
   }{%
     \edef\Hy@tempcolor{\csname @#1bordercolor\endcsname}%
@@ -15818,7 +15830,7 @@
   \edef\@processme{\noexpand\pdf@toks={\the\pdf@defaulttoks}}%
   \@processme
   \let\pdf@type\relax
-  \let\pdf@objdef\ltx@empty
+  \let\pdf@objdef\@empty
   \kvsetkeys{PDF}{#2}%
   \ifHy@pdfmarkerror
   \else
@@ -15832,14 +15844,14 @@
        \ifx\\#1\\%
          \literalps@out{%
            [%
-           \ifx\pdf@objdef\ltx@empty
+           \ifx\pdf@objdef\@empty
            \else
              /_objdef\string{\pdf@objdef\string}%
            \fi
            \the\pdf@toks\space\pdf@type\space pdfmark%
          }%
        \else
-         \ltx@IfUndefined{@\pdf@linktype color}{%
+         \@ifundefined{@\pdf@linktype color}{%
            \Hy@colorlink\@linkcolor
          }{%
            \expandafter\Hy@colorlink
@@ -15848,7 +15860,7 @@
          \pdf@rect{#1}%
          \literalps@out{%
            [%
-           \ifx\pdf@objdef\ltx@empty
+           \ifx\pdf@objdef\@empty
            \else
              /_objdef\string{\pdf@objdef\string}%
            \fi
@@ -15884,7 +15896,7 @@
   \begingroup
     \chardef\x=1 %
     \def\Hy@temp{#1}%
-    \ifx\Hy@temp\ltx@empty
+    \ifx\Hy@temp\@empty
       \chardef\x=0 %
     \else
       \def\y{\anchor@spot}%
@@ -15905,7 +15917,7 @@
     \ifmmode
       \def\Hy@LinkMath{$}%
     \else
-      \let\Hy@LinkMath\ltx@empty
+      \let\Hy@LinkMath\@empty
     \fi
     \ifHy@breaklinks
       \Hy@setouterhbox\pdf@box{%
@@ -15994,7 +16006,7 @@
 \def\pdf@linktype{link}
 % named object?
 \define@key{PDF}{objdef}{\edef\pdf@objdef{#1}}
-\let\pdf@objdef\ltx@empty
+\let\pdf@objdef\@empty
 % parameter is a stream of PDF
 \define@key{PDF}{Raw}{\pdf@addtoksx{#1}}
 % parameter is a name
@@ -16284,7 +16296,7 @@
 %    \begin{macrocode}
 %<*dvips>
 \providecommand*{\XR@ext}{pdf}
-\let\Hy@raisedlink\ltx@empty
+\let\Hy@raisedlink\@empty
 \def\literalps@out#1{\special{ps:SDict begin #1 end}}%
 \def\headerps@out#1{\special{! #1}}%
 \input{pdfmark.def}%
@@ -16459,7 +16471,7 @@
 %    \begin{macrocode}
 %<*vtexpdfmark>
 \providecommand*{\XR@ext}{pdf}
-\let\Hy@raisedlink\ltx@empty
+\let\Hy@raisedlink\@empty
 \def\literalps@out#1{\special{pS:#1}}%
 \def\headerps@out#1{\immediate\special{pS:#1}}%
 \input{pdfmark.def}%
@@ -16847,7 +16859,7 @@
 % |\special| commands.
 %<*dvipsone>
 \providecommand*{\XR@ext}{pdf}
-\let\Hy@raisedlink\ltx@empty
+\let\Hy@raisedlink\@empty
 \providecommand*\@pdfborder{0 0 1}
 \providecommand*\@pdfborderstyle{}
 \def\literalps@out#1{\special{ps:#1}}%
@@ -17047,14 +17059,14 @@
 %    \begin{macrocode}
 %<*tex4ht>
 \providecommand*{\XR@ext}{html}
-\let\Hy@raisedlink\ltx@empty
+\let\Hy@raisedlink\@empty
 \@ifpackageloaded{tex4ht}{%
   \Hy@InfoNoLine{tex4ht is already loaded}%
 }{%
   \RequirePackage[htex4ht]{tex4ht}%
 }
 \hyperlinkfileprefix{}
-\let\PDF@FinishDoc\ltx@empty
+\let\PDF@FinishDoc\@empty
 \def\PDF@SetupDoc{%
   \ifx\@baseurl\@empty
   \else
@@ -17164,7 +17176,7 @@
 \ifx \rEfLiNK \UnDef
   \def\rEfLiNK #1#2{#2}%
 \fi
-\let\backref\ltx@gobble
+\let\backref\@gobble
 %    \end{macrocode}
 %    Fix for tex4ht.
 %    \begin{macrocode}
@@ -17390,7 +17402,7 @@
 }}%
   \kvsetkeys{Form}{#1}%
 }
-\let\@endForm\ltx@empty
+\let\@endForm\@empty
 \def\@Gauge[#1]#2#3#4{% parameters, label, minimum, maximum
   \Hy@Message{Sorry, pdfmark drivers do not support FORM gauges}%
 }
@@ -17417,7 +17429,7 @@
       \string{#1\HyField@TheAnnotCount\string}%
     }%
   }%
-  \ifx\Fld@calculate@code\ltx@empty
+  \ifx\Fld@calculate@code\@empty
   \else
     \pdfmark{%
       pdfmark=/APPEND,%
@@ -17432,7 +17444,7 @@
 %    \begin{macrocode}
 \def\@TextField[#1]#2{% parameters, label
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \let\Fld@value\@empty
   \def\Fld@width{\DefaultWidthofText}%
   \def\Fld@height{%
@@ -17677,7 +17689,7 @@
 \def\@Form[#1]{%
   \Hy@Message{Sorry, HyperTeX does not support FORMs}%
 }
-\let\@endForm\ltx@empty
+\let\@endForm\@empty
 \def\@Gauge[#1]#2#3#4{% parameters, label, minimum, maximum
   \Hy@Message{Sorry, HyperTeX does not support FORM gauges}%
 }
@@ -17715,7 +17727,7 @@
 \def\@TextField[#1]#2{% parameters, label
   \let\Hy@reserved@a\@empty
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \bgroup
     \Field@toks={ }%
     \kvsetkeys{Field}{#1}%
@@ -17762,7 +17774,7 @@
 }
 \def\@ChoiceMenu[#1]#2#3{% parameters, label, choices
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \let\Hy@reserved@a\relax
   \begingroup
     \expandafter\Fld@findlength#3\\%
@@ -17860,8 +17872,8 @@
   }%
 % \hbox to 0pt{\hskip-\maxdimen{\pdfrefxform \the\pdflastxform}}%
 }%
-\let\HyField@afields\ltx@empty
-\let\HyField@cofields\ltx@empty
+\let\HyField@afields\@empty
+\let\HyField@cofields\@empty
 \@ifundefined{pdflastlink}
  {%
   \let\HyField@AddToFields\relax
@@ -17873,8 +17885,8 @@
     but other PDF viewers might complain%
   }}%
  {%
-  \let\HyField@AuxAddToFields\ltx@gobble
-  \let\HyField@AuxAddToCoFields\ltx@gobbletwo
+  \let\HyField@AuxAddToFields\@gobble
+  \let\HyField@AuxAddToCoFields\@gobbletwo
   \def\HyField@AfterAuxOpen{\Hy@AtBeginDocument}%
 %    \end{macrocode}
 %    Insertion sort for calculation field list.
@@ -17884,31 +17896,31 @@
   \def\HyField@ABD@AuxAddToCoFields#1#2{%
     \begingroup
       \Hy@safe@activestrue
-      \let\ltx@secondoftwo\relax
-      \ifx\HyField@cofields\ltx@empty
+      \let\@secondoftwo\relax
+      \ifx\HyField@cofields\@empty
         \xdef\HyField@cofields{%
-          \ltx@secondoftwo{#1}{ #2 0 R}%
+          \@secondoftwo{#1}{ #2 0 R}%
         }%
       \else
-        \let\ltx@secondoftwo\relax
+        \let\@secondoftwo\relax
         \def\HyField@AddCoField##1##2##3{%
-          \ifx##1\ltx@empty
-            \ltx@secondoftwo{#1}{ #2 0 R}%
-            \expandafter\ltx@gobble
+          \ifx##1\@empty
+            \@secondoftwo{#1}{ #2 0 R}%
+            \expandafter\@gobble
           \else
-            \ifnum\pdfstrcmp{##2}{#1}>\ltx@zero
-              \ltx@secondoftwo{#1}{ #2 0 R}%
-              \ltx@secondoftwo{##2}{##3}%
-              \expandafter\expandafter\expandafter\ltx@gobble
+            \ifnum\pdfstrcmp{##2}{#1}>\z@
+              \@secondoftwo{#1}{ #2 0 R}%
+              \@secondoftwo{##2}{##3}%
+              \expandafter\expandafter\expandafter\@gobble
             \else
-              \ltx@secondoftwo{##2}{##3}%
+              \@secondoftwo{##2}{##3}%
             \fi
           \fi
           \HyField@AddCoField
         }%
         \xdef\HyField@cofields{%
           \expandafter\HyField@AddCoField
-          \HyField@cofields\ltx@empty\ltx@empty\ltx@empty
+          \HyField@cofields\@empty\@empty\@empty
         }%
       \fi
     \endgroup
@@ -17939,7 +17951,7 @@
     \expandafter\HyField@@AddToFields\expandafter{%
       \the\pdflastlink
     }%
-    \ifx\Fld@calculate@code\ltx@empty
+    \ifx\Fld@calculate@code\@empty
     \else
       \begingroup
         \Hy@safe@activestrue
@@ -17982,7 +17994,7 @@
       \immediate\pdfobj{%
         <<%
           /Fields[\HyField@afields]%
-          \ifx\HyField@cofields\ltx@empty
+          \ifx\HyField@cofields\@empty
           \else
             /CO[\romannumeral-`\Q\HyField@cofields]%
           \fi
@@ -18025,18 +18037,18 @@
     \fbox{\textcolor{yellow}{\textsf{SubmitP}}}%
   }{SubmitP}%
 }
-\let\@endForm\ltx@empty
+\let\@endForm\@empty
 %    \end{macrocode}
 %    \begin{macrocode}
-\let\HyAnn@AbsPageLabel\ltx@empty
-\let\Fld@pageobjref\ltx@empty
-\ltx@IfUndefined{pdfpageref}{%
+\let\HyAnn@AbsPageLabel\@empty
+\let\Fld@pageobjref\@empty
+\@ifundefined{pdfpageref}{%
 }{%
-  \ltx@ifpackageloaded{zref-abspage}{%
+  \@ifpackageloaded{zref-abspage}{%
     \newcount\HyAnn@Count
-    \HyAnn@Count=\ltx@zero
+    \HyAnn@Count=\z@
     \def\HyAnn@AbsPageLabel{%
-      \global\advance\HyAnn@Count by\ltx@one
+      \global\advance\HyAnn@Count by\@ne
       \zref@labelbyprops{HyAnn@\the\HyAnn@Count}{abspage}%
       \zref@refused{HyAnn@\the\HyAnn@Count}%
     }%
@@ -18058,7 +18070,7 @@
 %    \begin{macrocode}
 \def\@TextField[#1]#2{% parameters, label
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \let\Fld@value\@empty
   \def\Fld@width{\DefaultWidthofText}%
   \def\Fld@height{%
@@ -18408,7 +18420,7 @@
 %    \end{macro}
 %    \begin{macro}{\@endForm}
 %    \begin{macrocode}
-\let\@endForm\ltx@empty
+\let\@endForm\@empty
 %    \end{macrocode}
 %    \end{macro}
 %
@@ -18455,7 +18467,7 @@
 %    \begin{macrocode}
 \def\HyField@AddToFields#1{%
   \@pdfm@mark{put @afields @#1\HyField@TheAnnotCount}%
-  \ifx\Fld@calculate@code\ltx@empty
+  \ifx\Fld@calculate@code\@empty
   \else
     \@pdfm@mark{put @corder @#1\HyField@TheAnnotCount}%
   \fi
@@ -18467,7 +18479,7 @@
 %    \begin{macrocode}
 \def\@TextField[#1]#2{% parameters, label
   \def\Fld@name{#2}%
-  \let\Fld@default\ltx@empty
+  \let\Fld@default\@empty
   \let\Fld@value\@empty
   \def\Fld@width{\DefaultWidthofText}%
   \def\Fld@height{%
@@ -18876,7 +18888,7 @@
     \else
       \expandafter
       \Hy@pstringdef\csname Hy@esc@\string#2\endcsname{#2}%
-      \ltx@ReturnAfterFi{%
+      \Hy@ReturnAfterFi{%
         \Hy@@escapeform#3\@nil
       }%
     \fi
@@ -19456,9 +19468,9 @@
   \def\HyPsd@SanitizeOut@BraceLeft#1(#2\@nil{%
     #1%
     \ifx\\#2\\%
-      \expandafter\ltx@gobble
+      \expandafter\@gobble
     \else
-      \expandafter\ltx@firstofone
+      \expandafter\@firstofone
     \fi
     {%
       \string\173%
@@ -19468,9 +19480,9 @@
   \def\HyPsd@SanitizeOut@BraceRight#1)#2\@nil{%
     #1%
     \ifx\\#2\\%
-      \expandafter\ltx@gobble
+      \expandafter\@gobble
     \else
-      \expandafter\ltx@firstofone
+      \expandafter\@firstofone
     \fi
     {%
       \string\175%
@@ -19821,7 +19833,7 @@
 %    is not executed, so there will be no destination for \cmd{addcontentsline}.
 %    So \cmd{\@chapter} is overloaded to avoid this:
 %    \begin{macrocode}
-\ltx@IfUndefined{@chapter}{}{%
+\@ifundefined{@chapter}{}{%
   \let\Hy@org@chapter\@chapter
   \def\@chapter{%
     \def\Hy@next{%
@@ -19831,7 +19843,7 @@
       }%
     }%
     \ifnum\c@secnumdepth>\m@ne
-      \ltx@IfUndefined{if@mainmatter}%
+      \@ifundefined{if@mainmatter}%
       \iftrue{\csname if@mainmatter\endcsname}%
         \let\Hy@next\relax
       \fi

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -592,12 +592,10 @@
 % change 2020-07-24: require newer pdftexcmds and remove fallback code
 % for version older than 2010.
 % change 2021-08-14: require expl3
+% change 2023-11-26: no longer require pdftexcmds
+% change 2023-11-26: no longer require expl3, we assume kernel is new enough.
 %    \begin{macrocode}
-\ifx\ExplSyntaxOn\undefined \RequirePackage{expl3}\fi
 \RequirePackage{iftex}[2019/10/24]
-\RequirePackage{pdftexcmds}[2018/09/10]
-%    \end{macrocode}
-%    \begin{macrocode}
 \RequirePackage{infwarerr}[2010/04/08]
 \RequirePackage{keyval}[1997/11/10]
 \RequirePackage{kvsetkeys}[2007/09/29]

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -10486,7 +10486,7 @@
   \@ifundefined{theH#1}{%
     \expandafter\def\csname theH#1\endcsname{}%
     \def\Hy@temp{\@elt{#1}}%
-    \@nelevel@sanitize\Hy@temp
+    \@onelevel@sanitize\Hy@temp
     \let\HyOrg@elt\@elt
     \edef\@elt{%
       \noexpand\HyCnt@LookForParentCounter
@@ -10509,7 +10509,7 @@
   \expandafter\let\expandafter\Hy@temp@A\csname cl@#2\endcsname
   \@ifundefined{cl@#2}{%
   }{%
-    \@nelevel@sanitize\Hy@temp@A
+    \@onelevel@sanitize\Hy@temp@A
     \edef\Hy@temp@A{%
       \noexpand\in@{\Hy@temp}{\Hy@temp@A}%
     }\Hy@temp@A
@@ -12355,7 +12355,7 @@
         \begingroup
           \let\protect\@unexpandable@protect
           \edef\Hy@temp{#1}%
-          \@nelevel@sanitize\Hy@temp
+          \@onelevel@sanitize\Hy@temp
           \global\let\HyInd@key\Hy@temp
         \endgroup
       }%

--- a/nameref.dtx
+++ b/nameref.dtx
@@ -33,7 +33,7 @@
 %<driver>\ProvidesFile{nameref.drv}
 % \fi
 % \ProvidesFile{nameref.dtx}
-  [2023-10-05 v2.54 Cross-referencing by name of section]%
+  [2023-11-14 v2.55 Cross-referencing by name of section]%
 %
 %
 % \iffalse
@@ -217,9 +217,14 @@
 %    \begin{macrocode}
 \RequirePackage{refcount}[2006/02/12]
 \RequirePackage{gettitlestring}[2009/12/18]
-\RequirePackage{ltxcmds}[2009/12/12]
 %    \end{macrocode}
-%
+
+%    \begin{macrocode}
+\ExplSyntaxOn
+\let\NR@GlobalAppendToMacro\tl_gput_right:Nn
+\ExplSyntaxOff
+
+%    \end{macrocode}
 % In formats older than 2023-06-01 
 % we redefine |\label| so that it also writes the name of the
 % current section to the .aux file; if the name ends in a dot,
@@ -228,7 +233,7 @@
 % used for cross-ref name, and file).
 %    \begin{macro}{\NR@strip@period}
 %    \begin{macrocode}
-\def\NR@strip@period#1.\ltx@empty#2\@nil{#1}
+\def\NR@strip@period#1.\@empty#2\@nil{#1}
 %    \end{macrocode}
 %    \end{macro}
 %
@@ -246,7 +251,7 @@
   \@onelevel@sanitize\@currentlabelname
   \edef\@currentlabelname{%
     \expandafter\NR@strip@period\@currentlabelname
-    \ltx@empty.\ltx@empty\@nil
+    \@empty.\@empty\@nil
   }%
 }
 %    \end{macrocode}
@@ -281,7 +286,7 @@
 % and also in hyperref.    
 %    \begin{macrocode}
 \providecommand*{\label@hook}{}
-\ltx@GlobalAppendToMacro{\label@hook}{%
+\NR@GlobalAppendToMacro{\label@hook}{%
     \NR@sanitize@labelname
     }
 \@ifl@t@r\fmtversion{2023-06-01}
@@ -461,9 +466,9 @@
 %
 %    \begin{macrocode}
 \@ifundefined{NR@nopatch@sectioning}
- {\ltx@IfUndefined{ifheadnameref}{%
+ {\@ifundefined{ifheadnameref}{%
   }{%
-    \ltx@IfUndefined{M@sect}{%
+    \@ifundefined{M@sect}{%
     }{%
       \let\NRorg@M@sect\M@sect
       \def\M@sect#1#2#3#4#5#6[#7][#8]{%
@@ -501,17 +506,17 @@
     \NR@chapter[{#1}]{#2}%
   }
   \@ifclassloaded{memoir}{%
-    \ltx@IfUndefined{ifheadnameref}{%
+    \@ifundefined{ifheadnameref}{%
     }{%
       \def\@chapter[#1]#2{%
-        \ltx@IfUndefined{ch@pt@c}{%
+        \@ifundefined{ch@pt@c}{%
           \NR@gettitle{#1}%
         }{%
-          \ifx\ch@pt@c\ltx@empty
+          \ifx\ch@pt@c\@empty
             \NR@gettitle{#2}%
           \else
             \def\NR@temp{#1}%
-            \ifx\NR@temp\ltx@empty
+            \ifx\NR@temp\@empty
               \expandafter\NR@gettitle\expandafter{\ch@pt@c}%
             \else
               \ifheadnameref
@@ -567,7 +572,7 @@
 %
 % Environment `description'.
 %    \begin{macrocode}
-  \ltx@IfUndefined{descriptionlabel}{%
+  \@ifundefined{descriptionlabel}{%
   }{%
     \@ifundefined{NR@nopatch@lists}
      {\let\NRorg@descriptionlabel\descriptionlabel
@@ -649,7 +654,7 @@
 %
 %    \begin{macrocode}
 \@ifundefined{NR@nopatch@theorem}{%
- \ltx@IfUndefined{@opargbegintheorem}{}{%
+ \@ifundefined{@opargbegintheorem}{}{%
    \let\NRorg@opargbegintheorem\@opargbegintheorem
    \def\@opargbegintheorem#1#2#3{%
      \NR@gettitle{#3}%

--- a/testfiles-pdftex/patch.tlg
+++ b/testfiles-pdftex/patch.tlg
@@ -25,7 +25,7 @@ l. ...\ShowCommand\endequation
 <argument> \@xfootnotenext 
 l. ...\ShowCommand\@xfootnotenext
 > \@footnotetext=\long macro:
-#1->\H@@footnotetext {\ifHy@nesting \expandafter \ltx@firstoftwo \else \expandafter \ltx@secondoftwo \fi {\expandafter \hyper@@anchor \expandafter {\Hy@footnote@currentHref }{\ignorespaces #1}}{\Hy@raisedlink {\expandafter \hyper@@anchor \expandafter {\Hy@footnote@currentHref }{\relax }}\let \@currentHref \Hy@footnote@currentHref \let \@currentlabelname \@empty \ignorespaces #1}}.
+#1->\H@@footnotetext {\ifHy@nesting \expandafter \@firstoftwo \else \expandafter \@secondoftwo \fi {\expandafter \hyper@@anchor \expandafter {\Hy@footnote@currentHref }{\ignorespaces #1}}{\Hy@raisedlink {\expandafter \hyper@@anchor \expandafter {\Hy@footnote@currentHref }{\relax }}\let \@currentHref \Hy@footnote@currentHref \let \@currentlabelname \@empty \ignorespaces #1}}.
 <argument> \@footnotetext 
 l. ...\ShowCommand\@footnotetext
 > \caption=macro:


### PR DESCRIPTION
This PR removes the dependency on the `ltxcmds` pakage.

Mostly `ltxcmds` provides LaTeX commands for other formats so is not needed in `hyperref`. (Just use `\@firstoftwo` rather than `\ltx@firstoftwo` etc)

It does provide a few extra features, here taken from expl3, and given Hy@ names

```
\let\Hy@LocalAppendToMacro\tl_put_right:Nn
\let\Hy@GlobalAppendToMacro\tl_gput_right:Nn
\let\Hy@ifempty\tl_if_empty:nTF
```

Also a couple of afterfi commands defined directly in the Hy@ prefix


```
\long\def\Hy@ReturnAfterFi#1\fi{\fi#1}
\long\def\Hy@ReturnAfterElseFi#1\else#2\fi{\fi#1}
```

The main advantage is an iterative step towards aligning the `hyperref` coding with the main kernel sources.