### PR TITLE
remove infwarerr

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,3 +1,6 @@
+2023-11-26  David Carlisle
+	* hyperref.dtx: Remove infwarerr
+
 2023-11-14 Ulrike Fischer
 	* remove ltxcmds dependency in hluatex.dtx
 	* remove ltxcmds dependency in nameref.dtx (v2.55)

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -606,11 +606,11 @@
 \RequirePackage{auxhook}[2009/12/14]
 \RequirePackage{nameref}[2012/07/28]
 \RequirePackage{etoolbox}
-\def\Hy@Error{\@PackageError{hyperref}}
-\def\Hy@Warning{\@PackageWarning{hyperref}}
-\def\Hy@WarningNoLine{\@PackageWarningNoLine{hyperref}}
-\def\Hy@Info{\@PackageInfo{hyperref}}
-\def\Hy@InfoNoLine{\@PackageInfoNoLine{hyperref}}
+\def\Hy@Error{\PackageError{hyperref}}
+\def\Hy@Warning{\PackageWarning{hyperref}}
+\def\Hy@WarningNoLine{\PackageWarningNoLine{hyperref}}
+\def\Hy@Info{\PackageInfo{hyperref}}
+\def\Hy@InfoNoLine#1{\PackageInfo{hyperref}{#1\@gobble}}
 \def\Hy@Message#1{%
   \GenericWarning{%
     (hyperref)\@spaces\@spaces\@spaces\@spaces


### PR DESCRIPTION
The infwarerr package doesn't seem offer any real benefit as hyperref is latex-only so use the standard warning commands.