### PR TITLE
Delete removed dependencies from CI package list

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -14,7 +14,6 @@ collection-basic
         carlisle
         colortbl
         epstopdf-pkg
-        etexcmds
         fancyhdr
         firstaid
         geometry
@@ -37,7 +36,6 @@ collection-basic
         latex-lab
         latexconfig
         letltxmacro
-        ltxcmds
         ltxmisc
         mfnfss
         mptopdf
@@ -136,7 +134,6 @@ collection-basic
         fontspec
         hologo
         index
-        infwarerr
         koma-script
         l3experimental
         latexbug
@@ -150,7 +147,6 @@ collection-basic
         pdflscape
         pdfmanagement-testphase
         pdfpages
-        pdftexcmds
         ragged2e
         setspace
         textcase

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,7 @@ name: Automated testing
 on:
   push:
     branches:
-      - "*"
+      - "**"
       - "!test*"
 jobs:
   run-checks:


### PR DESCRIPTION
Dependencies
- `etexcmds` was removed in 549ee5d (Merge pull request `#276` from muzimuzhi/drop-etexcmds, 2023-02-19)
- `infwarerr` was removed in 908e303 (remove infwarerr (`#317`), 2023-11-26)
- `ltxcmds` and `pdftexcmds` were removed in 396ba2b (remove ltxcmds dependency (`#312`), 2023-11-26)

BTW, from a successful [CI run](https://github.com/muzimuzhi/hyperref/actions/runs/6998733956), it seems that `ltxmisc` is not needed too.