### PR TITLE
Remove loading `infwarerr`

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -38,7 +38,6 @@ collection-basic
         latexconfig
         letltxmacro
         ltxcmds
-        ltxmisc
         mfnfss
         mptopdf
         natbib

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -2,7 +2,10 @@ Version: 2023-11-26 v7.01g
 		nameref 2023-11-26 v2.56 
 		backref 2023-11-26 v1.44
 
-2023-11-26  David Carlisle
+2023-11-28 Yukai Chou
+	* remove infwarerr dependency in hyperref.dtx
+
+2023-11-26 David Carlisle
 	* hyperref.dtx: Remove infwarerr
 
 2023-11-26 Ulrike Fischer

--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -596,7 +596,6 @@
 % change 2023-11-26: no longer require expl3, we assume kernel is new enough.
 %    \begin{macrocode}
 \RequirePackage{iftex}[2019/10/24]
-\RequirePackage{infwarerr}[2010/04/08]
 \RequirePackage{keyval}[1997/11/10]
 \RequirePackage{kvsetkeys}[2007/09/29]
 \RequirePackage{kvdefinekeys}[2011/04/07]


### PR DESCRIPTION
Remove the `\RequirePackage{infwarerr}[...]` line that #317 left, as pointed out in https://github.com/latex3/hyperref/pull/319#issuecomment-1827452597.

Feel free to use a better description in ChangeLog.