### PR TITLE
xr-hyper.dtx: Minor copyediting

### DIFF
--- a/xr-hyper.dtx
+++ b/xr-hyper.dtx
@@ -95,7 +95,7 @@
 % In the \LaTeX{} release 2023-06-01 the label syntax of \pkg{hyperref}
 % and the \LaTeX{} kernel have been synchronized and there is no longer
 % a need for two packages. \pkg{xr-hyper} already works with all documents --
-% it is not required to load\pkg{hyperref} -- and its code will move in the
+% it is not required to load \pkg{hyperref} -- and its code will move in the
 % next \LaTeX{} release into the \pkg{xr} package. Then \pkg{xr-hyper} can be
 % deprecated.
 % 
@@ -108,7 +108,7 @@
 % If one document needs to refer to sections of another, say |aaa.tex|,
 % then this package may be loaded in the main file, and the command
 % \begin{verbatim}
-% |\externaldocument{aaa}|
+% \externaldocument{aaa}
 % \end{verbatim}
 %  given in the preamble.
 %
@@ -140,7 +140,7 @@
 % always work, it can be disabled by specifying \texttt{[nocite]} after the
 % \meta{prefix}:
 % \begin{verbatim}
-%  \externaldocument[][nocite]{aaa}
+% \externaldocument[][nocite]{aaa}
 % \end{verbatim}  
 % 
 % The `document' referred to by the main argument \meta{document} is the file


### PR DESCRIPTION
* xr-hyper.dtx: Add misssing space. (section{Usage}): Remove shortvrb guards inside verbatim environment.
Delete leading space.