### PR TITLE
DeclareDocumentMetadata -> DocumentMetadata

### DIFF
--- a/doc/hyperref-doc.tex
+++ b/doc/hyperref-doc.tex
@@ -598,9 +598,9 @@ changed behaviour if the new pdfmanagement and so the new generic \xpackage{hype
 option     & remark \\\hline
 all driver options, e.g. \texttt{pdftex} & often not needed, as detected automatically\\
 implicit   \\
-pdfa       & no-op with new pdfmanagement, set the standard in \cs{DeclareDocumentMetadata}.\\
+pdfa       & no-op with new pdfmanagement, set the standard in \cs{DocumentMetadata}.\\
 unicode    & is the default now anyway\\
-pdfversion & no-op with new pdfmanagement, set the version in \cs{DeclareDocumentMetadata}.\\
+pdfversion & no-op with new pdfmanagement, set the version in \cs{DocumentMetadata}.\\
 bookmarks  & this will probably change at some time. \\
 backref &\\
 pagebackref & \\

--- a/hyperref-patches.dtx
+++ b/hyperref-patches.dtx
@@ -28,7 +28,7 @@
 %
 %<*driver>
 \RequirePackage{pdfmanagement-testphase}
-\DeclareDocumentMetadata{pdfstandard=A-2b}
+\DocumentMetadata{pdfstandard=A-2b}
 \makeatletter
 \declare@file@substitution{doc.sty}{doc-v3beta.sty}
 \makeatother


### PR DESCRIPTION
Changes `\DeclareDocumentMetadata` to `\DocumentMetadata` in hyperref-patches.dtx and two instances in hyperref-doc.tex.