### PR TITLE
Make hyper@refstepcounter use Hy@chapapp

### DIFF
--- a/hyperref.dtx
+++ b/hyperref.dtx
@@ -10396,7 +10396,18 @@
 %    \begin{macro}{\hyper@refstepcounter}
 %    changed 2026-02-22 to use \cs{MakeLinkTarget}
 %    \begin{macrocode}
-\def\hyper@refstepcounter#1{\ifHy@hypertexnames\MakeLinkTarget{#1}\else\MakeLinkTarget[#1]{} \fi}
+\def\hyper@refstepcounter#1{%
+  \ifHy@hypertexnames
+    \edef\Hy@param{#1}%
+    \ifx\Hy@param\Hy@chapterstring
+      \MakeLinkTarget[\Hy@chapapp]{#1}%
+    \else
+      \MakeLinkTarget{#1}%
+    \fi
+  \else
+    \MakeLinkTarget[#1]{}%
+  \fi
+}
 %    \end{macrocode}
 %    \end{macro}
 %    \begin{macro}{\Hy@ProvideTheHCounter}


### PR DESCRIPTION
After commit 987e71f1, the internal name of pdf links for chapters (generated automatically by `\hyper@refstepcounter`) ignores `\Hy@chapapp`, which is relevant for the `appendix` package (as described in bug #423). This patch fixes this.